### PR TITLE
Add deployment test heading for FTP verification

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: FTP Deploy to ProFreeHost
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: FTP Deploy
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        with:
+          server: ${{ secrets.FTP_SERVER }}
+          username: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          port: ${{ secrets.FTP_PORT }}
+          server-dir: ${{ secrets.FTP_SERVER_DIR }}
+          protocol: ftp
+          timeout: 600
+          exclude: |
+            **/.git*
+            **/.github/**
+            **/.DS_Store
+            uploads/**
+            README*.md
+            config.php
+          dangerous-clean-slate: false

--- a/index.php
+++ b/index.php
@@ -121,6 +121,8 @@ $card = fetch_random_card($pdo, $langFilter);
         </form>
     </header>
 
+    <h1>Test</h1>
+
     <?php if ($flash): ?>
         <div class="flash <?= h($flash['type']) ?>"><?= h($flash['message']) ?></div>
     <?php endif; ?>


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that deploys the site to ProFreeHost via FTP
- exclude repository metadata, uploads, and sensitive config.php from automatic deployment
- add a temporary `<h1>Test</h1>` heading on the home page to verify that deployments are working

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68d68eb00ca0832bafffddcc2fdfb662