### PR TITLE
Enhance mobile learning experience

### DIFF
--- a/index.php
+++ b/index.php
@@ -9,24 +9,50 @@ $action = $_GET['a'] ?? 'learn';
 $langFilter = isset($_GET['lang']) && $_GET['lang'] !== '' ? substr($_GET['lang'], 0, 10) : null;
 $searchTerm = trim($_GET['q'] ?? '');
 
-function fetch_random_card(PDO $pdo, ?string $lang): ?array
+function fetch_random_cards(PDO $pdo, ?string $lang, int $limit = 1, bool $requireMeaning = false): array
 {
-    $sql = 'SELECT w.*, t.lang_code, t.other_script, t.meaning, t.example
-            FROM words w
-            LEFT JOIN translations t ON t.word_id = w.id';
+    $limit = max(1, $limit);
+    $conditions = [];
     $params = [];
 
     if ($lang !== null) {
-        $sql .= ' AND t.lang_code = ?';
+        $conditions[] = 't.lang_code = ?';
         $params[] = $lang;
     }
 
-    $sql .= ' ORDER BY RAND() LIMIT 1';
+    if ($requireMeaning) {
+        $conditions[] = "(t.meaning IS NOT NULL AND t.meaning <> '')";
+    }
+
+    $sql = 'SELECT w.*, t.lang_code, t.other_script, t.meaning, t.example
+            FROM words w
+            LEFT JOIN (
+                SELECT tr.word_id, tr.lang_code, tr.other_script, tr.meaning, tr.example
+                FROM translations tr
+                INNER JOIN (
+                    SELECT word_id, MIN(id) AS min_id
+                    FROM translations
+                    GROUP BY word_id
+                ) picked ON picked.word_id = tr.word_id AND picked.min_id = tr.id
+            ) t ON t.word_id = w.id';
+
+    if ($conditions) {
+        $sql .= ' WHERE ' . implode(' AND ', $conditions);
+    }
+
+    $sql .= ' ORDER BY RAND() LIMIT ' . $limit;
 
     $stmt = $pdo->prepare($sql);
     $stmt->execute($params);
 
-    return $stmt->fetch() ?: null;
+    return $stmt->fetchAll();
+}
+
+function fetch_random_card(PDO $pdo, ?string $lang): ?array
+{
+    $cards = fetch_random_cards($pdo, $lang, 1);
+
+    return $cards[0] ?? null;
 }
 
 if ($action === 'create_word' && is_post()) {
@@ -47,6 +73,17 @@ if ($action === 'create_word' && is_post()) {
     } catch (RuntimeException $e) {
         flash($e->getMessage(), 'error');
         redirect('index.php');
+    }
+
+    $recordedAudio = $_POST['recorded_audio'] ?? '';
+
+    if ($audioPath === null && $recordedAudio !== '') {
+        try {
+            $audioPath = save_recorded_audio($recordedAudio, $UPLOAD_DIR);
+        } catch (RuntimeException $e) {
+            flash($e->getMessage(), 'error');
+            redirect('index.php');
+        }
     }
 
     $pdo->beginTransaction();
@@ -98,6 +135,19 @@ if ($searchTerm !== '') {
 }
 
 $card = fetch_random_card($pdo, $langFilter);
+$carouselCards = fetch_random_cards($pdo, $langFilter, 8);
+$memoryPairs = fetch_random_cards($pdo, $langFilter, 6, true);
+$memoryPairs = array_values(array_filter($memoryPairs, static fn(array $row): bool => ($row['meaning'] ?? '') !== ''));
+$memoryData = array_map(
+    static fn(array $row): array => [
+        'id' => (int) $row['id'],
+        'hebrew' => $row['hebrew'] ?? '',
+        'meaning' => $row['meaning'] ?? '',
+        'other_script' => $row['other_script'] ?? '',
+        'transliteration' => $row['transliteration'] ?? '',
+    ],
+    $memoryPairs
+);
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -127,56 +177,84 @@ $card = fetch_random_card($pdo, $langFilter);
         <div class="flash <?= h($flash['type']) ?>"><?= h($flash['message']) ?></div>
     <?php endif; ?>
 
-    <section class="card">
-        <h2>Flashcard</h2>
-        <?php if ($card): ?>
-            <div class="grid grid-2">
-                <div>
-                    <div class="badge">Hebrew</div>
-                    <h1 class="hebrew-word"><?= h($card['hebrew']) ?></h1>
-                    <?php if (!empty($card['transliteration'])): ?>
-                        <div class="badge">Transliteration</div>
-                        <div><?= h($card['transliteration']) ?></div>
-                    <?php endif; ?>
-                    <?php if (!empty($card['part_of_speech'])): ?>
-                        <div class="badge">Part of speech</div>
-                        <div><?= h($card['part_of_speech']) ?></div>
-                    <?php endif; ?>
-                    <?php if (!empty($card['notes'])): ?>
-                        <div class="badge">Notes</div>
-                        <div><?= nl2br(h($card['notes'])) ?></div>
-                    <?php endif; ?>
-                    <?php if (!empty($card['audio_path'])): ?>
-                        <audio class="audio" controls src="<?= h($card['audio_path']) ?>"></audio>
-                    <?php endif; ?>
-                </div>
-                <div>
-                    <div class="badge">Translation</div>
-                    <p>
-                        <strong>Lang:</strong> <?= h($card['lang_code'] ?? '—') ?><br>
-                        <strong>Other script:</strong> <?= h($card['other_script'] ?? '—') ?><br>
-                        <strong>Meaning:</strong> <?= h($card['meaning'] ?? '—') ?><br>
-                        <?php if (!empty($card['example'])): ?>
-                            <strong>Example:</strong> <?= nl2br(h($card['example'])) ?><br>
+    <section class="card flashcard-section">
+        <div class="section-heading">
+            <div>
+                <h2>Flashcards</h2>
+                <p class="section-subtitle">Swipe right and left to review fresh cards.</p>
+            </div>
+            <div class="flex wrap">
+                <a class="btn secondary" href="index.php">Shuffle</a>
+                <a class="btn" href="index.php?lang=ru">RU</a>
+                <a class="btn" href="index.php?lang=en">EN</a>
+                <a class="btn" href="index.php?lang=ar">AR</a>
+            </div>
+        </div>
+        <?php if ($carouselCards): ?>
+            <div class="flashcard-track" tabindex="0">
+                <?php foreach ($carouselCards as $item): ?>
+                    <article class="flashcard" role="listitem">
+                        <header class="flashcard-header">
+                            <span class="badge">Hebrew</span>
+                            <?php if (!empty($item['part_of_speech'])): ?>
+                                <span class="badge badge-muted"><?= h($item['part_of_speech']) ?></span>
+                            <?php endif; ?>
+                        </header>
+                        <h3 class="hebrew-word"><?= h($item['hebrew']) ?></h3>
+                        <?php if (!empty($item['transliteration'])): ?>
+                            <p class="flashcard-text"><span class="badge">Transliteration</span> <?= h($item['transliteration']) ?></p>
                         <?php endif; ?>
-                    </p>
-                    <div class="flex">
-                        <a class="btn secondary" href="index.php">New Random</a>
-                        <a class="btn" href="index.php?lang=ru">RU</a>
-                        <a class="btn" href="index.php?lang=en">EN</a>
-                        <a class="btn" href="index.php?lang=ar">AR</a>
-                    </div>
-                </div>
+                        <?php if (!empty($item['notes'])): ?>
+                            <p class="flashcard-text"><?= nl2br(h($item['notes'])) ?></p>
+                        <?php endif; ?>
+                        <div class="flashcard-translation">
+                            <span class="badge">Meaning</span>
+                            <p class="flashcard-text">
+                                <strong><?= h($item['lang_code'] ?? '—') ?>:</strong>
+                                <?= h($item['meaning'] ?? '—') ?>
+                            </p>
+                            <?php if (!empty($item['other_script'])): ?>
+                                <p class="flashcard-text alt-script"><?= h($item['other_script']) ?></p>
+                            <?php endif; ?>
+                            <?php if (!empty($item['example'])): ?>
+                                <p class="flashcard-text example"><?= nl2br(h($item['example'])) ?></p>
+                            <?php endif; ?>
+                        </div>
+                        <?php if (!empty($item['audio_path'])): ?>
+                            <audio class="audio" controls preload="none" src="<?= h($item['audio_path']) ?>"></audio>
+                        <?php endif; ?>
+                    </article>
+                <?php endforeach; ?>
             </div>
         <?php else: ?>
             <p>No words yet. Add some below.</p>
         <?php endif; ?>
     </section>
 
+    <section class="card memory-section">
+        <div class="section-heading">
+            <div>
+                <h2>Memory Trainer</h2>
+                <p class="section-subtitle">Match each Hebrew word with its translation to build recall.</p>
+            </div>
+            <button type="button" class="btn secondary" id="memory-reset" <?= empty($memoryPairs) ? 'disabled' : '' ?>>Shuffle board</button>
+        </div>
+        <?php if ($memoryPairs): ?>
+            <div class="memory-status">
+                <span>Matches: <strong id="memory-matches">0</strong> / <?= count($memoryPairs) ?></span>
+                <span id="memory-feedback" role="status" aria-live="polite"></span>
+            </div>
+            <div class="memory-board" id="memory-board" aria-label="Memory trainer board"></div>
+        <?php else: ?>
+            <p class="memory-empty">Add translations to play the memory game.</p>
+        <?php endif; ?>
+    </section>
+
     <section class="card">
         <h3>Quick Add Word</h3>
-        <form method="post" enctype="multipart/form-data" action="index.php?a=create_word">
+        <form method="post" enctype="multipart/form-data" action="index.php?a=create_word" id="quick-add-form">
             <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
+            <input type="hidden" name="recorded_audio" id="recorded_audio">
             <div class="grid grid-3">
                 <div>
                     <label for="hebrew">Hebrew *</label>
@@ -195,7 +273,17 @@ $card = fetch_random_card($pdo, $langFilter);
             <textarea id="notes" name="notes" rows="3" placeholder="Any nuances, gender, irregular forms..."></textarea>
 
             <label for="audio">Pronunciation (audio/mp3/wav/ogg ≤ 10MB)</label>
-            <input id="audio" type="file" name="audio" accept="audio/*">
+            <div class="record-row">
+                <input id="audio" type="file" name="audio" accept="audio/*">
+                <div class="record-controls" id="record-controls">
+                    <button type="button" class="btn secondary" id="record-toggle" data-state="idle">🎙️ Record</button>
+                    <button type="button" class="btn" id="record-save" disabled>Use recording</button>
+                </div>
+            </div>
+            <div class="record-preview" id="record-preview" hidden>
+                <audio id="recorded-audio" controls></audio>
+                <button type="button" class="btn secondary" id="record-discard">Discard</button>
+            </div>
 
             <div class="grid grid-3">
                 <div>
@@ -260,6 +348,264 @@ $card = fetch_random_card($pdo, $langFilter);
             <p>No results found.</p>
         </section>
     <?php endif; ?>
+    <?php if (!empty($memoryData)): ?>
+        <script type="application/json" id="memory-data"><?= json_encode($memoryData, JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT) ?></script>
+    <?php endif; ?>
 </div>
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+    const memoryDataEl = document.getElementById('memory-data');
+    const board = document.getElementById('memory-board');
+    const matchesEl = document.getElementById('memory-matches');
+    const feedbackEl = document.getElementById('memory-feedback');
+    const resetBtn = document.getElementById('memory-reset');
+
+    if (memoryDataEl && board && matchesEl) {
+        const basePairs = JSON.parse(memoryDataEl.textContent || '[]');
+        const matchedPairs = new Set();
+        let flipped = [];
+
+        const pickLabel = (item) => item.meaning || item.other_script || item.transliteration || '—';
+
+        const buildDeck = () => {
+            const deck = [];
+            basePairs.forEach((item) => {
+                deck.push({ pairId: String(item.id), type: 'hebrew', label: item.hebrew, announce: `Hebrew: ${item.hebrew}` });
+                deck.push({ pairId: String(item.id), type: 'translation', label: pickLabel(item), announce: `Translation: ${pickLabel(item)}` });
+            });
+            for (let i = deck.length - 1; i > 0; i -= 1) {
+                const j = Math.floor(Math.random() * (i + 1));
+                [deck[i], deck[j]] = [deck[j], deck[i]];
+            }
+            return deck;
+        };
+
+        const clearBoardState = () => {
+            matchedPairs.clear();
+            flipped = [];
+            matchesEl.textContent = '0';
+            if (feedbackEl) {
+                feedbackEl.textContent = '';
+            }
+        };
+
+        const announceMatch = () => {
+            if (!feedbackEl) {
+                return;
+            }
+            if (matchedPairs.size === basePairs.length) {
+                feedbackEl.textContent = 'All pairs matched! Great job!';
+            } else {
+                feedbackEl.textContent = `Matched ${matchedPairs.size} of ${basePairs.length} pairs.`;
+            }
+        };
+
+        const renderBoard = () => {
+            const deck = buildDeck();
+            clearBoardState();
+            board.innerHTML = '';
+            deck.forEach((card, index) => {
+                const button = document.createElement('button');
+                button.type = 'button';
+                button.className = 'memory-card';
+                button.dataset.pairId = card.pairId;
+                button.dataset.type = card.type;
+                button.setAttribute('aria-label', card.announce);
+                button.setAttribute('data-index', String(index));
+
+                const span = document.createElement('span');
+                span.textContent = card.label;
+                button.appendChild(span);
+
+                button.addEventListener('click', () => handleFlip(button));
+                board.appendChild(button);
+            });
+        };
+
+        const unflipCards = (first, second) => {
+            setTimeout(() => {
+                first.classList.remove('flipped');
+                second.classList.remove('flipped');
+                first.disabled = false;
+                second.disabled = false;
+                flipped = [];
+            }, 900);
+        };
+
+        const handleFlip = (button) => {
+            if (button.classList.contains('matched') || flipped.includes(button)) {
+                return;
+            }
+
+            button.classList.add('flipped');
+            button.disabled = true;
+            flipped.push(button);
+
+            if (flipped.length === 2) {
+                const [first, second] = flipped;
+                const isMatch = first.dataset.pairId === second.dataset.pairId && first.dataset.type !== second.dataset.type;
+                if (isMatch) {
+                    first.classList.add('matched');
+                    second.classList.add('matched');
+                    matchedPairs.add(first.dataset.pairId || '');
+                    matchesEl.textContent = String(matchedPairs.size);
+                    flipped = [];
+                    announceMatch();
+                } else {
+                    unflipCards(first, second);
+                }
+            }
+        };
+
+        resetBtn?.addEventListener('click', () => {
+            renderBoard();
+        });
+
+        renderBoard();
+    }
+
+    const recordToggle = document.getElementById('record-toggle');
+    const recordSave = document.getElementById('record-save');
+    const recordDiscard = document.getElementById('record-discard');
+    const recordPreview = document.getElementById('record-preview');
+    const recordedAudioElement = document.getElementById('recorded-audio');
+    const recordedAudioInput = document.getElementById('recorded_audio');
+    const fileInput = document.getElementById('audio');
+
+    let mediaRecorder = null;
+    let audioChunks = [];
+    let mediaStream = null;
+    let recordedBlob = null;
+
+    const stopStream = () => {
+        if (mediaStream) {
+            mediaStream.getTracks().forEach((track) => track.stop());
+            mediaStream = null;
+        }
+    };
+
+    const resetRecording = () => {
+        if (mediaRecorder && mediaRecorder.state !== 'inactive') {
+            mediaRecorder.stop();
+        }
+        recordedBlob = null;
+        audioChunks = [];
+        recordedAudioInput.value = '';
+        if (recordPreview) {
+            recordPreview.hidden = true;
+        }
+        if (recordSave) {
+            recordSave.disabled = true;
+        }
+        if (recordToggle) {
+            recordToggle.dataset.state = 'idle';
+            recordToggle.textContent = '🎙️ Record';
+            recordToggle.disabled = false;
+        }
+        stopStream();
+    };
+
+    const handleDataAvailable = (event) => {
+        if (event.data && event.data.size > 0) {
+            audioChunks.push(event.data);
+        }
+    };
+
+    const handleStop = () => {
+        recordedBlob = new Blob(audioChunks, { type: audioChunks[0]?.type || 'audio/webm' });
+        if (recordPreview && recordedAudioElement && recordedBlob.size > 0) {
+            recordedAudioElement.src = URL.createObjectURL(recordedBlob);
+            recordPreview.hidden = false;
+            if (recordSave) {
+                recordSave.disabled = false;
+            }
+        }
+        if (recordToggle) {
+            recordToggle.dataset.state = 'idle';
+            recordToggle.textContent = '🎙️ Record again';
+            recordToggle.disabled = false;
+        }
+        stopStream();
+    };
+
+    const startRecording = async () => {
+        if (!navigator.mediaDevices || typeof MediaRecorder === 'undefined') {
+            if (recordToggle) {
+                recordToggle.textContent = 'Recording unsupported';
+                recordToggle.disabled = true;
+            }
+            return;
+        }
+
+        try {
+            mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            mediaRecorder = new MediaRecorder(mediaStream);
+            audioChunks = [];
+
+            mediaRecorder.addEventListener('dataavailable', handleDataAvailable);
+            mediaRecorder.addEventListener('stop', handleStop, { once: true });
+            mediaRecorder.start();
+            if (recordToggle) {
+                recordToggle.dataset.state = 'recording';
+                recordToggle.textContent = '⏹️ Stop';
+            }
+        } catch (err) {
+            console.error('Recorder error', err);
+            if (recordToggle) {
+                recordToggle.textContent = 'Permission denied';
+                recordToggle.disabled = true;
+            }
+        }
+    };
+
+    const stopRecording = () => {
+        if (mediaRecorder && mediaRecorder.state !== 'inactive') {
+            mediaRecorder.stop();
+        }
+        if (recordToggle) {
+            recordToggle.dataset.state = 'processing';
+            recordToggle.textContent = 'Processing…';
+            recordToggle.disabled = true;
+        }
+    };
+
+    recordToggle?.addEventListener('click', () => {
+        const state = recordToggle.dataset.state;
+        if (state === 'idle' || state === 'saved') {
+            resetRecording();
+            startRecording();
+        } else if (state === 'recording') {
+            stopRecording();
+        }
+    });
+
+    recordSave?.addEventListener('click', () => {
+        if (!recordedBlob) {
+            return;
+        }
+        const reader = new FileReader();
+        reader.addEventListener('loadend', () => {
+            if (typeof reader.result === 'string') {
+                recordedAudioInput.value = reader.result;
+                if (recordToggle) {
+                    recordToggle.dataset.state = 'saved';
+                    recordToggle.textContent = 'Recording ready ✓';
+                }
+            }
+        });
+        reader.readAsDataURL(recordedBlob);
+    });
+
+    recordDiscard?.addEventListener('click', () => {
+        resetRecording();
+    });
+
+    fileInput?.addEventListener('change', () => {
+        if (fileInput.files && fileInput.files.length > 0) {
+            resetRecording();
+        }
+    });
+});
+</script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -119,6 +119,10 @@ label {
     align-items: center;
 }
 
+.flex.wrap {
+    flex-wrap: wrap;
+}
+
 .grid {
     display: grid;
     gap: 12px;
@@ -173,4 +177,214 @@ label {
 
 .form-actions {
     margin-top: 12px;
+}
+
+.section-heading {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+
+.section-subtitle {
+    margin: 4px 0 0;
+    color: var(--muted);
+    font-size: 14px;
+}
+
+.flashcard-section {
+    overflow: hidden;
+}
+
+.flashcard-track {
+    display: flex;
+    gap: 16px;
+    overflow-x: auto;
+    padding-bottom: 12px;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+}
+
+.flashcard-track::-webkit-scrollbar {
+    height: 6px;
+}
+
+.flashcard-track::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.12);
+    border-radius: 999px;
+}
+
+.flashcard {
+    flex: 0 0 280px;
+    background: rgba(14, 21, 33, 0.9);
+    border: 1px solid rgba(74, 163, 255, 0.15);
+    border-radius: 18px;
+    padding: 18px;
+    scroll-snap-align: start;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.flashcard-header {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.flashcard-text {
+    margin: 4px 0;
+    font-size: 15px;
+    line-height: 1.4;
+}
+
+.flashcard-translation {
+    margin-top: auto;
+    padding-top: 10px;
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.flashcard .badge {
+    font-size: 11px;
+}
+
+.badge-muted {
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--text);
+}
+
+.alt-script {
+    font-size: 14px;
+    color: var(--muted);
+}
+
+.example {
+    font-size: 14px;
+    opacity: 0.85;
+}
+
+.memory-section {
+    border: 1px solid rgba(74, 163, 255, 0.15);
+}
+
+.memory-status {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 12px;
+    font-size: 14px;
+}
+
+.memory-board {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 12px;
+}
+
+.memory-card {
+    position: relative;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 16px;
+    background: rgba(13, 20, 31, 0.85);
+    color: var(--text);
+    min-height: 90px;
+    padding: 12px;
+    font-size: 18px;
+    font-weight: 600;
+    text-align: center;
+    cursor: pointer;
+    transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.memory-card span {
+    display: block;
+    pointer-events: none;
+}
+
+.memory-card:hover,
+.memory-card:focus-visible {
+    transform: translateY(-2px);
+    border-color: var(--accent);
+}
+
+.memory-card.flipped {
+    background: rgba(74, 163, 255, 0.15);
+    border-color: rgba(74, 163, 255, 0.5);
+}
+
+.memory-card.matched {
+    background: rgba(34, 197, 94, 0.15);
+    border-color: rgba(34, 197, 94, 0.5);
+    color: #bef7d4;
+    cursor: default;
+}
+
+.memory-empty {
+    color: var(--muted);
+}
+
+.record-row {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.record-row input[type="file"] {
+    flex: 1 1 220px;
+}
+
+.record-controls {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.record-preview {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    margin-top: 10px;
+}
+
+.record-preview[hidden] {
+    display: none;
+}
+
+@media (max-width: 720px) {
+    .container {
+        padding: 16px;
+    }
+
+    .flashcard {
+        flex-basis: 80vw;
+    }
+
+    .memory-board {
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    }
+
+    .memory-card {
+        font-size: 16px;
+        min-height: 80px;
+    }
+}
+
+@media (max-width: 480px) {
+    .header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .flashcard {
+        flex-basis: 85vw;
+    }
+
+    .memory-card {
+        font-size: 15px;
+        padding: 10px;
+    }
 }


### PR DESCRIPTION
## Summary
- add reusable random card queries and build a horizontal flashcard carousel optimized for touch
- introduce a memory-match training game with responsive layout adjustments
- enable in-browser pronunciation recording and process uploaded audio data server-side

## Testing
- php -l index.php
- php -l config.php

------
https://chatgpt.com/codex/tasks/task_e_68d6958ea090832b9d0d7e4ecbf92950