### PR TITLE
Handle recorded audio codecs metadata

### DIFF
--- a/config.php
+++ b/config.php
@@ -138,11 +138,11 @@ function save_recorded_audio(?string $dataUrl, string $uploadDir): ?string
         return null;
     }
 
-    if (!preg_match('#^data:(audio/(?:webm|ogg|mp3|mpeg|wav));base64,(.+)$#', $dataUrl, $matches)) {
+    if (!preg_match('#^data:(audio/(?:webm|ogg|mp3|mpeg|wav))(?:;codecs=[^;]+)?;base64,(.+)$#i', $dataUrl, $matches)) {
         throw new RuntimeException('Unrecognized recorded audio format.');
     }
 
-    $mime = $matches[1];
+    $mime = strtolower($matches[1]);
     $base64 = str_replace(' ', '+', $matches[2]);
     $binary = base64_decode($base64, true);
 


### PR DESCRIPTION
## Summary
- allow recorded audio data URLs with optional codec metadata
- normalize detected MIME type casing before validation

## Testing
- php -l config.php

------
https://chatgpt.com/codex/tasks/task_e_68d6aa159c10832baf4e4b04d8548965