### PR TITLE
Add SQLite fallback for admin tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .idea/
 .DS_Store
 .deploy_secret.php
+database.sqlite


### PR DESCRIPTION
## Summary
- add an automatic SQLite fallback database that initializes the schema when MySQL is unavailable
- expose helper utilities for database-specific SQL fragments and update search/random queries to use them
- ignore the generated SQLite database file so it is not committed accidentally

## Testing
- php -l config.php
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68d6aa3ec534832baf21034d3933540a