### PR TITLE
Add base schema migrations and global error reporting

### DIFF
--- a/index.php
+++ b/index.php
@@ -23,18 +23,6 @@ if (!isset($_SESSION['selected_deck']) || (int) $_SESSION['selected_deck'] <= 0)
 }
 $selectedDeckId = (int) ($_SESSION['selected_deck'] ?? $defaultDeckId);
 
-function request_wants_json(): bool
-{
-    $accept = $_SERVER['HTTP_ACCEPT'] ?? '';
-    $requestedWith = $_SERVER['HTTP_X_REQUESTED_WITH'] ?? '';
-
-    if (stripos($requestedWith, 'xmlhttprequest') !== false) {
-        return true;
-    }
-
-    return str_contains($accept, 'application/json');
-}
-
 $starterPhrases = [
     ['hebrew' => 'מה שלומך?', 'transliteration' => 'ma shlomkha?', 'meaning' => 'How are you?', 'lang' => 'en', 'example' => 'מה שלומך היום?'],
     ['hebrew' => 'נעים להכיר', 'transliteration' => 'naim lehakir', 'meaning' => 'Nice to meet you', 'lang' => 'en', 'example' => 'נעים להכיר אותך סוף סוף.'],

--- a/migrations/000_create_core_tables.sql
+++ b/migrations/000_create_core_tables.sql
@@ -1,0 +1,60 @@
+CREATE TABLE IF NOT EXISTS words (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    hebrew VARCHAR(255) NOT NULL,
+    transliteration VARCHAR(255) NULL,
+    part_of_speech VARCHAR(64) NULL,
+    notes TEXT NULL,
+    audio_path VARCHAR(255) NULL,
+    image_path VARCHAR(255) NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_words_hebrew (hebrew)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS translations (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    word_id INT NOT NULL,
+    lang_code VARCHAR(16) NOT NULL,
+    other_script VARCHAR(255) NULL,
+    meaning VARCHAR(255) NULL,
+    example TEXT NULL,
+    CONSTRAINT fk_translations_word FOREIGN KEY (word_id) REFERENCES words(id) ON DELETE CASCADE,
+    INDEX idx_translations_word (word_id),
+    INDEX idx_translations_lang (lang_code)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    email VARCHAR(190) UNIQUE,
+    password_hash VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS tags (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(190) UNIQUE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS word_tags (
+    word_id INT NOT NULL,
+    tag_id INT NOT NULL,
+    PRIMARY KEY (word_id, tag_id),
+    CONSTRAINT fk_word_tags_word FOREIGN KEY (word_id) REFERENCES words(id) ON DELETE CASCADE,
+    CONSTRAINT fk_word_tags_tag FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS streaks (
+    user_id INT NOT NULL,
+    day DATE NOT NULL,
+    learned INT DEFAULT 0,
+    correct_rate DECIMAL(5,2) DEFAULT 0.00,
+    PRIMARY KEY (user_id, day),
+    CONSTRAINT fk_streaks_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS achievements (
+    user_id INT NOT NULL,
+    code VARCHAR(64) NOT NULL,
+    unlocked_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, code),
+    CONSTRAINT fk_achievements_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/migrations/005_extend_user_progress.sql
+++ b/migrations/005_extend_user_progress.sql
@@ -1,0 +1,109 @@
+-- Ensure the spaced-repetition fields exist on user_progress
+SET @table := 'user_progress';
+
+SET @col := (SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @table AND COLUMN_NAME = 'user_id');
+SET @stmt := IF(@col = 0,
+    'ALTER TABLE `user_progress` ADD COLUMN `user_id` INT NULL AFTER `id`;',
+    'SELECT 1;'
+);
+PREPARE stmt FROM @stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @col := (SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @table AND COLUMN_NAME = 'interval_days');
+SET @stmt := IF(@col = 0,
+    'ALTER TABLE `user_progress` ADD COLUMN `interval_days` SMALLINT DEFAULT 0 AFTER `word_id`;',
+    'SELECT 1;'
+);
+PREPARE stmt FROM @stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @col := (SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @table AND COLUMN_NAME = 'ease');
+SET @stmt := IF(@col = 0,
+    'ALTER TABLE `user_progress` ADD COLUMN `ease` DECIMAL(3,2) DEFAULT 2.50 AFTER `interval_days`;',
+    'SELECT 1;'
+);
+PREPARE stmt FROM @stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @col := (SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @table AND COLUMN_NAME = 'due_at');
+SET @stmt := IF(@col = 0,
+    'ALTER TABLE `user_progress` ADD COLUMN `due_at` DATETIME NULL AFTER `ease`;',
+    'SELECT 1;'
+);
+PREPARE stmt FROM @stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @col := (SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @table AND COLUMN_NAME = 'reps');
+SET @stmt := IF(@col = 0,
+    'ALTER TABLE `user_progress` ADD COLUMN `reps` INT DEFAULT 0 AFTER `due_at`;',
+    'SELECT 1;'
+);
+PREPARE stmt FROM @stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @col := (SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @table AND COLUMN_NAME = 'lapses');
+SET @stmt := IF(@col = 0,
+    'ALTER TABLE `user_progress` ADD COLUMN `lapses` INT DEFAULT 0 AFTER `reps`;',
+    'SELECT 1;'
+);
+PREPARE stmt FROM @stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @col := (SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @table AND COLUMN_NAME = 'last_result');
+SET @stmt := IF(@col = 0,
+    "ALTER TABLE `user_progress` ADD COLUMN `last_result` ENUM('again','hard','good','easy') NULL AFTER `lapses`;",
+    'SELECT 1;'
+);
+PREPARE stmt FROM @stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Ensure we have a composite key over the numeric identifiers
+SET @constraint := (SELECT COUNT(*)
+                    FROM information_schema.TABLE_CONSTRAINTS
+                    WHERE TABLE_SCHEMA = DATABASE()
+                      AND TABLE_NAME = @table
+                      AND CONSTRAINT_TYPE = 'UNIQUE'
+                      AND CONSTRAINT_NAME = 'uniq_user_word');
+SET @stmt := IF(@constraint = 0,
+    'ALTER TABLE `user_progress` ADD UNIQUE KEY `uniq_user_word` (`user_id`, `word_id`);',
+    'SELECT 1;'
+);
+PREPARE stmt FROM @stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Add index for due dates if missing
+SET @idx := (SELECT COUNT(*) FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @table AND INDEX_NAME = 'idx_user_progress_due');
+SET @stmt := IF(@idx = 0,
+    'CREATE INDEX `idx_user_progress_due` ON `user_progress` (`due_at`);',
+    'SELECT 1;'
+);
+PREPARE stmt FROM @stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Ensure foreign keys exist when the referenced tables are available
+SET @fk := (SELECT COUNT(*) FROM information_schema.REFERENTIAL_CONSTRAINTS WHERE CONSTRAINT_SCHEMA = DATABASE() AND CONSTRAINT_NAME = 'fk_user_progress_user');
+SET @stmt := IF(@fk = 0,
+    'ALTER TABLE `user_progress` ADD CONSTRAINT `fk_user_progress_user` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE;',
+    'SELECT 1;'
+);
+PREPARE stmt FROM @stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @fk := (SELECT COUNT(*) FROM information_schema.REFERENTIAL_CONSTRAINTS WHERE CONSTRAINT_SCHEMA = DATABASE() AND CONSTRAINT_NAME = 'fk_user_progress_word');
+SET @stmt := IF(@fk = 0,
+    'ALTER TABLE `user_progress` ADD CONSTRAINT `fk_user_progress_word` FOREIGN KEY (`word_id`) REFERENCES `words`(`id`) ON DELETE CASCADE;',
+    'SELECT 1;'
+);
+PREPARE stmt FROM @stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/styles.css
+++ b/styles.css
@@ -24,6 +24,25 @@ body {
     font: 16px/1.5 "Inter", "Segoe UI", -apple-system, BlinkMacSystemFont, sans-serif;
 }
 
+.error-page {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    background: var(--bg);
+    padding: 24px;
+}
+
+.error-card {
+    background: var(--card);
+    box-shadow: var(--shadow);
+    border-radius: 16px;
+    padding: 32px;
+    max-width: 420px;
+    width: 100%;
+    text-align: center;
+}
+
 .sr-only {
     position: absolute;
     width: 1px;


### PR DESCRIPTION
## Summary
- add base schema migrations so core tables and spaced-repetition fields are created consistently
- extend the user_progress migration to add SRS columns, indexes, and foreign keys when missing
- install global error handling that returns flash alerts or JSON responses and add styling for the standalone error page

## Testing
- php -l config.php
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68d6bf0b46a0832bba9f2f7eabf4d4f4