### PR TITLE
Refine dashboard layout and modularize sections

### DIFF
--- a/index.php
+++ b/index.php
@@ -14,10 +14,11 @@ if (!isset($_SESSION['user_identifier'])) {
 
 $userIdentifier = $_SESSION['user_identifier'];
 $screen = $_GET['screen'] ?? 'home';
-$screen = in_array($screen, ['home', 'library', 'settings'], true) ? $screen : 'home';
+$allowedScreens = ['home', 'library', 'settings'];
+if (!in_array($screen, $allowedScreens, true)) {
+    $screen = 'home';
+}
 $action = $_GET['a'] ?? 'view';
-$langFilter = isset($_GET['lang']) && $_GET['lang'] !== '' ? substr($_GET['lang'], 0, 10) : null;
-$searchTerm = trim($_GET['q'] ?? '');
 
 $defaultDeckId = ensure_default_deck($pdo);
 if (!isset($_SESSION['selected_deck']) || (int) $_SESSION['selected_deck'] <= 0) {
@@ -37,7 +38,6 @@ handle_dashboard_action($action, $pdo, [
 $selectedDeckId = (int) ($_SESSION['selected_deck'] ?? $selectedDeckId);
 
 $decks = fetch_decks_with_stats($pdo, $userIdentifier);
-
 if (!$decks) {
     $defaultDeckId = ensure_default_deck($pdo);
     $decks = fetch_decks_with_stats($pdo, $userIdentifier);
@@ -48,817 +48,137 @@ foreach ($decks as $deck) {
     $deckLookup[(int) $deck['id']] = $deck;
 }
 
-if (!isset($deckLookup[$selectedDeckId])) {
+if (isset($_GET['deck'])) {
+    $requestedDeckId = (int) $_GET['deck'];
+    if (isset($deckLookup[$requestedDeckId])) {
+        $_SESSION['selected_deck'] = $requestedDeckId;
+        $selectedDeckId = $requestedDeckId;
+    }
+}
+
+if (!isset($deckLookup[$selectedDeckId]) && isset($deckLookup[$defaultDeckId])) {
     $selectedDeckId = $defaultDeckId;
     $_SESSION['selected_deck'] = $selectedDeckId;
 }
 
 $selectedDeck = $deckLookup[$selectedDeckId] ?? null;
-$deckSample = $selectedDeck ? fetch_deck_sample_card($pdo, $selectedDeckId) : null;
-$deckHistory = $selectedDeck ? fetch_deck_learning_history($pdo, $selectedDeckId, $userIdentifier) : [];
-$groupedDecks = group_decks_by_category($decks);
+$sampleCard = $selectedDeck ? fetch_deck_sample_card($pdo, $selectedDeckId) : null;
+$recentHistory = $selectedDeck ? array_slice(fetch_deck_learning_history($pdo, $selectedDeckId, $userIdentifier), 0, 5) : [];
 
-$popularDecks = array_filter($decks, static fn(array $deck): bool => (float) $deck['rating'] >= 4.5 || (int) $deck['learners_count'] >= 200);
-$categories = array_keys($groupedDecks);
-sort($categories);
+$dueSummary = ['total' => null, 'deck' => null];
+try {
+    $stmt = $pdo->prepare('SELECT COUNT(*) FROM user_progress WHERE user_identifier = ? AND (due_at IS NULL OR due_at <= NOW())');
+    $stmt->execute([$userIdentifier]);
+    $dueSummary['total'] = (int) $stmt->fetchColumn();
 
-$card = fetch_random_card($pdo, $langFilter, $selectedDeckId);
-$carouselCards = fetch_random_cards($pdo, $langFilter, 8, false, $selectedDeckId);
-$memoryPairs = fetch_random_cards($pdo, $langFilter, 6, true, $selectedDeckId);
-$memoryPairs = array_values(array_filter($memoryPairs, static fn(array $row): bool => ($row['meaning'] ?? '') !== ''));
-$memoryData = array_map(
-    static function (array $row): array {
-        $isReversed = isset($row['is_reversed']) && (int) $row['is_reversed'] === 1;
-        $hebrew = $row['hebrew'] ?? '';
-        $meaning = $row['meaning'] ?? '';
-        if ($isReversed) {
-            return [
-                'id' => (int) $row['id'],
-                'hebrew' => $meaning,
-                'meaning' => $hebrew,
-                'other_script' => $row['other_script'] ?? '',
-                'transliteration' => $row['transliteration'] ?? '',
-            ];
-        }
-
-        return [
-            'id' => (int) $row['id'],
-            'hebrew' => $hebrew,
-            'meaning' => $meaning,
-            'other_script' => $row['other_script'] ?? '',
-            'transliteration' => $row['transliteration'] ?? '',
-        ];
-    },
-    $memoryPairs
-);
-
-$interfaceLocale = 'he-IL';
-if ($langFilter === 'ar') {
-    $interfaceLocale = 'ar';
-} elseif ($langFilter === 'ru') {
-    $interfaceLocale = 'ru-RU';
-} elseif ($langFilter === 'en') {
-    $interfaceLocale = 'en-US';
+    if ($selectedDeckId > 0) {
+        $stmt = $pdo->prepare(
+            'SELECT COUNT(*)
+             FROM user_progress up
+             INNER JOIN deck_words dw ON dw.word_id = up.word_id
+             WHERE up.user_identifier = ?
+               AND dw.deck_id = ?
+               AND (up.due_at IS NULL OR up.due_at <= NOW())'
+        );
+        $stmt->execute([$userIdentifier, $selectedDeckId]);
+        $dueSummary['deck'] = (int) $stmt->fetchColumn();
+    }
+} catch (Throwable $e) {
+    $dueSummary = ['total' => null, 'deck' => null];
 }
 
-$hasDeckCards = (int) ($selectedDeck['cards_count'] ?? 0) > 0;
-
-$searchResults = [];
-if ($searchTerm !== '') {
-    // בניית שאילתת סיכום התרגומים באמצעות פונקציה קיימת
-    $translationSummarySelect = db_translation_summary_select();
-
-    $sql = 'SELECT w.*, ' . $translationSummarySelect . ',
-                   GROUP_CONCAT(DISTINCT d.name SEPARATOR ", ") AS deck_names
-            FROM words w
-            LEFT JOIN translations t ON t.word_id = w.id
-            LEFT JOIN deck_words dw ON dw.word_id = w.id
-            LEFT JOIN decks d ON d.id = dw.deck_id
-            WHERE w.hebrew LIKE ?
-               OR w.transliteration LIKE ?
-               OR t.meaning LIKE ?
-               OR t.other_script LIKE ?
-            GROUP BY w.id
-            ORDER BY w.created_at DESC
-            LIMIT 50';
-
-    $stmt = $pdo->prepare($sql);
-    $like = '%' . $searchTerm . '%';
-    $stmt->execute([$like, $like, $like, $like]);
-    $searchResults = $stmt->fetchAll();
-}
-
-
+$navLinks = [
+    'home' => 'דף הבית',
+    'library' => 'ספריה',
+    'settings' => 'העדפות',
+];
 ?>
 <!DOCTYPE html>
-<html lang="<?= h(str_replace('_', '-', $interfaceLocale)) ?>">
+<html lang="he" dir="rtl">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Hebrew Study Hub</title>
     <link rel="stylesheet" href="styles.css">
-    <script src="scripts/apply-direction.js"></script>
+    <script src="scripts/apply-direction.js" defer></script>
 </head>
-<body class="app-body" data-screen="<?= h($screen) ?>" data-locale="<?= h($interfaceLocale) ?>" data-lang-filter="<?= h($langFilter ?? '') ?>" data-tts-back-lang="<?= h($selectedDeck['tts_back_lang'] ?? 'he-IL') ?>">
-<div class="app-shell">
-    <header class="app-header">
-        <div class="header-main">
+<body class="app-body" data-screen="<?= h($screen) ?>">
+<div class="app-container">
+    <aside class="app-sidebar" role="complementary">
+        <div class="brand-block">
+            <span class="brand-icon" aria-hidden="true">🧠</span>
             <h1>Hebrew Study Hub</h1>
-            <p class="header-sub">Tailored decks, smart drills, and responsive design inspired by mobile-first study apps.</p>
+            <p>חוויית לימוד בהשראת Noji — כרטיסיות דיגיטליות וחזרתיות מבוזרת.</p>
         </div>
-        <form method="get" action="index.php" class="search-form">
-            <input type="hidden" name="screen" value="<?= h($screen) ?>" data-search-screen>
-            <input type="text" name="q" placeholder="Search cards" value="<?= h($searchTerm) ?>" data-rtl-sensitive>
-            <button class="btn primary" type="submit">Search</button>
-        </form>
-    </header>
-
-    <div class="toast-region" aria-live="assertive" aria-atomic="true">
-        <div class="toast" id="app-toast" role="status" hidden></div>
-    </div>
-
-    <?php if ($flash): ?>
-        <div class="flash <?= h($flash['type']) ?>"><?= h($flash['message']) ?></div>
-    <?php endif; ?>
-
-    <main class="app-content">
-        <section class="screen" data-screen="home" <?= $screen === 'home' ? '' : 'hidden' ?>>
-            <div class="hero-card">
-                <div class="hero-info">
-                    <h2><?= h($selectedDeck['name'] ?? 'Deck') ?></h2>
-                    <p><?= h($selectedDeck['description'] ?? 'Curated words to master Hebrew every day.') ?></p>
-                    <div class="hero-stats">
-                        <span><strong><?= (int) ($selectedDeck['cards_count'] ?? 0) ?></strong> Cards</span>
-                        <span><strong><?= (int) ($selectedDeck['studied_count'] ?? 0) ?></strong> Studied</span>
-                        <span><strong><?= (int) ($selectedDeck['progress_percent'] ?? 0) ?>%</strong> Complete</span>
-                    </div>
-                    <div class="hero-actions">
-                        <?php if ($hasDeckCards): ?>
-                            <a class="btn primary" href="#flashcards">Start session</a>
-                        <?php else: ?>
-                            <a class="btn primary" href="#quick-add-form" data-roll-example="true">צור כרטיס ראשון</a>
-                        <?php endif; ?>
-                        <a class="btn ghost" href="?screen=library">Deck settings</a>
-                    </div>
-                </div>
-                <div class="hero-illustration">
-                    <span class="deck-icon"><?= h($selectedDeck['icon'] ?? 'sparkles') ?></span>
-                </div>
+        <nav class="app-nav" aria-label="תפריט ראשי">
+            <?php foreach ($navLinks as $key => $label): ?>
+                <a class="app-nav__link<?= $screen === $key ? ' is-active' : '' ?>" href="index.php?screen=<?= h($key) ?>">
+                    <?= h($label) ?>
+                </a>
+            <?php endforeach; ?>
+        </nav>
+        <div class="sidebar-footer">
+            <p class="sidebar-note">התחבר/י כדי לעקוב אחרי ההתקדמות האישית שלך לאורך זמן.</p>
+            <div class="sidebar-actions">
+                <a class="btn ghost" href="login.php">כניסה</a>
+                <a class="btn ghost" href="register.php">הרשמה</a>
             </div>
+        </div>
+    </aside>
 
-            <section class="card flashcard-section" id="flashcards">
-                <div class="section-heading">
-                    <div>
-                        <h2>Flashcards</h2>
-                        <p class="section-subtitle">Swipe through your deck with reversible cards and inline audio.</p>
-                    </div>
-                    <div class="tag-group">
-                        <a class="btn ghost" href="index.php?screen=home">Shuffle</a>
-                        <label class="sr-only" for="lang-filter">Filter language</label>
-                        <select id="lang-filter" name="lang">
-                            <option value="">All languages</option>
-                            <option value="ru" <?= $langFilter === 'ru' ? 'selected' : '' ?>>Русский</option>
-                            <option value="en" <?= $langFilter === 'en' ? 'selected' : '' ?>>English</option>
-                            <option value="ar" <?= $langFilter === 'ar' ? 'selected' : '' ?>>العربية</option>
+    <main class="app-main" role="main">
+        <header class="main-header">
+            <div>
+                <h2><?= h($navLinks[$screen] ?? 'דף הבית') ?></h2>
+                <p class="main-subtitle">ממשק נקי שמרכז את כל מה שצריך כדי לשנן מילים בקצב שלך.</p>
+            </div>
+            <div class="deck-picker">
+                <?php if ($decks): ?>
+                    <form method="get" action="index.php" class="deck-picker__form">
+                        <input type="hidden" name="screen" value="<?= h($screen) ?>">
+                        <label for="deck-select">Deck פעיל</label>
+                        <select id="deck-select" name="deck" onchange="this.form.submit()">
+                            <?php foreach ($decks as $deck): ?>
+                                <option value="<?= (int) $deck['id'] ?>"<?= $deck['id'] == $selectedDeckId ? ' selected' : '' ?>>
+                                    <?= h($deck['name']) ?>
+                                </option>
+                            <?php endforeach; ?>
                         </select>
-                    </div>
-                </div>
-                <?php if ($carouselCards): ?>
-                    <div class="flashcard-track" tabindex="0">
-                        <?php foreach ($carouselCards as $item): ?>
-                            <?php $isReversed = isset($item['is_reversed']) && (int) $item['is_reversed'] === 1; ?>
-                            <article class="flashcard" role="listitem">
-                                <header class="flashcard-header">
-                                    <span class="badge">Deck</span>
-                                    <span class="badge badge-muted"><?= h($selectedDeck['name'] ?? 'Deck') ?></span>
-                                </header>
-                                <?php if ($isReversed): ?>
-                                    <h3 class="hebrew-word"><?= h($item['meaning'] ?? '') ?></h3>
-                                    <p class="flashcard-text"><span class="badge">Hebrew</span> <?= h($item['hebrew'] ?? '') ?></p>
-                                <?php else: ?>
-                                    <h3 class="hebrew-word"><?= h($item['hebrew'] ?? '') ?></h3>
-                                    <?php if (!empty($item['transliteration'])): ?>
-                                        <p class="flashcard-text"><span class="badge">Transliteration</span> <?= h($item['transliteration']) ?></p>
-                                    <?php endif; ?>
-                                <?php endif; ?>
-                                <div class="flashcard-translation">
-                                    <span class="badge">Meaning</span>
-                                    <p class="flashcard-text">
-                                        <strong><?= h($item['lang_code'] ?? '—') ?>:</strong>
-                                        <?= h($item['meaning'] ?? '—') ?>
-                                    </p>
-                                    <?php if (!empty($item['other_script'])): ?>
-                                        <p class="flashcard-text alt-script"><?= h($item['other_script']) ?></p>
-                                    <?php endif; ?>
-                                    <?php if (!empty($item['example'])): ?>
-                                        <p class="flashcard-text example"><?= nl2br(h($item['example'])) ?></p>
-                                    <?php endif; ?>
-                                </div>
-                                <?php if (!empty($item['audio_path'])): ?>
-                                    <audio class="audio" controls preload="none" src="<?= h($item['audio_path']) ?>"></audio>
-                                <?php endif; ?>
-                            </article>
-                        <?php endforeach; ?>
-                    </div>
-                <?php else: ?>
-                    <p>No cards yet in this deck. Add words using the quick form or start with ready-made phrases.</p>
-                    <form method="post" action="index.php?a=seed_openers" class="seed-form">
-                        <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
-                        <input type="hidden" name="deck_id" value="<?= (int) $selectedDeckId ?>">
-                        <button type="submit" class="btn primary seed-btn">+ הוסף 10 ביטויי פתיחה</button>
+                        <noscript>
+                            <button type="submit" class="btn ghost">עדכן</button>
+                        </noscript>
                     </form>
                 <?php endif; ?>
-            </section>
-
-            <section class="card memory-section">
-                <div class="section-heading">
-                    <div>
-                        <h2>Memory Trainer</h2>
-                        <p class="section-subtitle">Match Hebrew words with their translation to reinforce recognition.</p>
-                    </div>
-                    <button type="button" class="btn ghost" id="memory-reset" <?= empty($memoryPairs) ? 'disabled' : '' ?>>Shuffle board</button>
-                </div>
-                <div class="memory-status">
-                    <span>Matches: <strong id="memory-matches">0</strong> / <?= count($memoryPairs) ?></span>
-                    <span id="memory-feedback" aria-live="polite" role="status"></span>
-                </div>
-                <div class="memory-board" id="memory-board" aria-label="Memory trainer board" data-empty="<?= empty($memoryPairs) ? '1' : '0' ?>"></div>
-                <?php if (empty($memoryPairs)): ?>
-                    <p class="memory-empty">Add translations to play the memory game.</p>
-                <?php endif; ?>
-            </section>
-
-            <section class="card">
-                <h3>Quick Add Word</h3>
-                <form method="post" enctype="multipart/form-data" action="index.php?a=create_word" id="quick-add-form">
-                    <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
-                    <input type="hidden" name="recorded_audio" id="recorded_audio">
-                    <div class="grid grid-3 responsive">
-                        <div>
-                            <label for="hebrew">Hebrew *</label>
-                            <input id="hebrew" name="hebrew" required placeholder="לְדֻגְמָה" dir="rtl" inputmode="text" autocomplete="off" spellcheck="false" lang="he">
-                        </div>
-                        <div>
-                            <label for="transliteration">Transliteration</label>
-                            <input id="transliteration" name="transliteration" placeholder="le-dugma" autocomplete="off">
-                        </div>
-                        <div>
-                            <label for="part_of_speech">Part of speech</label>
-                            <select id="part_of_speech" name="part_of_speech">
-                                <option value="">Unspecified</option>
-                                <option value="noun">Noun</option>
-                                <option value="verb">Verb</option>
-                                <option value="adj">Adjective</option>
-                                <option value="adv">Adverb</option>
-                                <option value="phrase">Phrase</option>
-                                <option value="prep">Preposition</option>
-                                <option value="pron">Pronoun</option>
-                            </select>
-                        </div>
-                    </div>
-                    <label for="notes">Notes</label>
-                    <textarea id="notes" name="notes" rows="3" placeholder="Any nuances, gender, irregular forms..." maxlength="320"></textarea>
-
-                    <label for="audio">Pronunciation (audio/mp3/wav/ogg ≤ 10MB)</label>
-                    <div class="record-row">
-                        <input id="audio" type="file" name="audio" accept="audio/*">
-                        <div class="record-controls" id="record-controls">
-                            <button type="button" class="btn ghost" id="record-toggle" data-state="idle">🎙️ Record</button>
-                            <button type="button" class="btn primary" id="record-save" disabled>Use recording</button>
-                        </div>
-                    </div>
-                    <p class="record-support" id="record-support-message" hidden>Recording is not supported in this browser.</p>
-                    <div class="record-preview" id="record-preview" hidden>
-                        <audio id="recorded-audio" controls></audio>
-                        <button type="button" class="btn ghost" id="record-discard">Discard</button>
-                    </div>
-
-                    <div class="grid grid-3 responsive">
-                        <div>
-                            <label for="lang_code">Translation language</label>
-                            <input id="lang_code" name="lang_code" placeholder="e.g., ru, en, fr" pattern="^[a-z]{2}(-[A-Z]{2})?$" title="Use a two-letter language code, e.g. en or ru">
-                        </div>
-                        <div>
-                            <label for="other_script">Other script (spelling)</label>
-                            <input id="other_script" name="other_script" placeholder="пример / example">
-                        </div>
-                        <div>
-                            <label for="meaning">Meaning (gloss)</label>
-                            <input id="meaning" name="meaning" placeholder="example / пример" maxlength="160">
-                        </div>
-                    </div>
-                    <label for="example">Example (optional)</label>
-                    <textarea id="example" name="example" rows="2" placeholder="Use in a sentence" maxlength="320"></textarea>
-
-                    <label for="deck_id">Add to deck</label>
-                    <select id="deck_id" name="deck_id">
-                        <?php foreach ($decks as $deckOption): ?>
-                            <option value="<?= (int) $deckOption['id'] ?>" <?= (int) $deckOption['id'] === $selectedDeckId ? 'selected' : '' ?>>
-                                <?= h($deckOption['name']) ?>
-                            </option>
-                        <?php endforeach; ?>
-                    </select>
-
-                    <div class="form-actions">
-                        <button class="btn primary" type="submit">Add</button>
-                    </div>
-                </form>
-            </section>
-
-            <?php if ($searchTerm !== '' && $searchResults): ?>
-                <section class="card">
-                    <h3>Search Results</h3>
-                    <table class="table">
-                        <thead>
-                        <tr>
-                            <th>Hebrew</th>
-                            <th>Translit</th>
-                            <th>POS</th>
-                            <th>Decks</th>
-                            <th>Translations</th>
-                            <th></th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        <?php foreach ($searchResults as $row): ?>
-                            <tr>
-                                <td><?= h($row['hebrew']) ?></td>
-                                <td><?= h($row['transliteration']) ?></td>
-                                <td><?= h($row['part_of_speech']) ?></td>
-                                <td><?= h($row['deck_names'] ?? '—') ?></td>
-                                <td><pre class="translations-pre"><?= h($row['translations_summary']) ?></pre></td>
-                                <td><a class="btn ghost" href="edit_word.php?id=<?= (int) $row['id'] ?>">Edit</a></td>
-                            </tr>
-                        <?php endforeach; ?>
-                        </tbody>
-                    </table>
-                </section>
-            <?php elseif ($searchTerm !== ''): ?>
-                <section class="card">
-                    <h3>Search Results</h3>
-                    <p>No results found.</p>
-                </section>
-            <?php endif; ?>
-        </section>
-
-        <section class="screen" data-screen="library" <?= $screen === 'library' ? '' : 'hidden' ?>>
-            <div class="card">
-                <div class="library-header">
-                    <div>
-                        <h2>Decks library</h2>
-                        <p class="section-subtitle">Explore curated decks shared by the community.</p>
-                    </div>
-                    <button class="btn primary" data-dialog-open="create-deck">New deck</button>
-                </div>
-
-                <div class="filter-bar">
-                    <button class="filter-btn active" data-filter="all">All (<?= count($decks) ?>)</button>
-                    <button class="filter-btn" data-filter="popular">Popular (<?= count($popularDecks) ?>)</button>
-                    <?php foreach ($categories as $category): ?>
-                        <button class="filter-btn" data-filter="<?= h($category) ?>"><?= h($category) ?></button>
-                    <?php endforeach; ?>
-                </div>
-
-                <div class="deck-grid" id="deck-grid">
-                    <?php foreach ($decks as $deck): ?>
-                        <article class="deck-card" data-category="<?= h($deck['category'] ?? 'General') ?>" data-popular="<?= ((float) $deck['rating'] >= 4.5 || (int) $deck['learners_count'] >= 200) ? '1' : '0' ?>" data-frozen="<?= (int) ($deck['is_frozen'] ?? 0) ?>" data-reversed="<?= (int) ($deck['is_reversed'] ?? 0) ?>">
-                            <header class="deck-card-header" style="--deck-accent: <?= h($deck['color'] ?? '#6366f1') ?>;">
-                                <div class="deck-card-icon"><?= h($deck['icon'] ?? 'book') ?></div>
-                                <button class="deck-card-menu" data-deck-sheet="<?= (int) $deck['id'] ?>" aria-label="Deck options">⋮</button>
-                            </header>
-                            <h3><?= h($deck['name']) ?></h3>
-                            <p class="deck-card-desc"><?= h($deck['description'] ?? 'No description yet.') ?></p>
-                            <dl class="deck-card-stats">
-                                <div>
-                                    <dt>Cards</dt>
-                                    <dd><?= (int) $deck['cards_count'] ?></dd>
-                                </div>
-                                <div>
-                                    <dt>Rating</dt>
-                                    <dd><?= number_format((float) $deck['rating'], 1) ?></dd>
-                                </div>
-                                <div>
-                                    <dt>Studiers</dt>
-                                    <dd><?= (int) $deck['learners_count'] ?></dd>
-                                </div>
-                            </dl>
-                            <div class="deck-card-progress">
-                                <div class="progress-bar"><span style="width: <?= (int) $deck['progress_percent'] ?>%"></span></div>
-                                <span><?= (int) $deck['progress_percent'] ?>% mastered</span>
-                            </div>
-                            <?php if ((int) $deck['id'] === $selectedDeckId): ?>
-                                <span class="badge badge-active">Selected</span>
-                            <?php endif; ?>
-                        </article>
-                    <?php endforeach; ?>
-                </div>
             </div>
-
-            <?php if ($selectedDeck): ?>
-                <section class="card deck-detail">
-                    <header>
-                        <h3><?= h($selectedDeck['name']) ?> controls</h3>
-                        <p class="section-subtitle">Fine-tune text-to-speech, AI generation, offline mode and more.</p>
-                    </header>
-                    <div class="deck-settings-grid">
-                        <form method="post" action="index.php?a=update_deck_details" class="deck-form">
-                            <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
-                            <input type="hidden" name="deck_id" value="<?= (int) $selectedDeckId ?>">
-                            <label for="deck-name">Deck name</label>
-                            <input id="deck-name" name="name" value="<?= h($selectedDeck['name']) ?>" required>
-                            <label for="deck-description">Description</label>
-                            <textarea id="deck-description" name="description" rows="3" placeholder="Tell learners what to expect."><?= h($selectedDeck['description'] ?? '') ?></textarea>
-                            <label for="deck-category">Category</label>
-                            <input id="deck-category" name="category" value="<?= h($selectedDeck['category'] ?? 'General') ?>">
-                            <button class="btn primary" type="submit">Save deck</button>
-                        </form>
-
-                        <div class="deck-toggles">
-                            <form method="post" action="index.php?a=toggle_deck_flag" class="toggle-row">
-                                <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
-                                <input type="hidden" name="deck_id" value="<?= (int) $selectedDeckId ?>">
-                                <input type="hidden" name="flag" value="ai_generation_enabled">
-                                <input type="hidden" name="value" value="<?= (int) ($selectedDeck['ai_generation_enabled'] ?? 0) ? 0 : 1 ?>">
-                                <label>AI cards generation <span class="badge">Beta</span></label>
-                                <button class="switch <?= (int) ($selectedDeck['ai_generation_enabled'] ?? 0) ? 'on' : '' ?>" type="submit" aria-pressed="<?= (int) ($selectedDeck['ai_generation_enabled'] ?? 0) ? 'true' : 'false' ?>">
-                                    <span class="sr-only"><?= (int) ($selectedDeck['ai_generation_enabled'] ?? 0) ? 'On' : 'Off' ?></span>
-                                </button>
-                            </form>
-                            <form method="post" action="index.php?a=toggle_deck_flag" class="toggle-row">
-                                <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
-                                <input type="hidden" name="deck_id" value="<?= (int) $selectedDeckId ?>">
-                                <input type="hidden" name="flag" value="offline_enabled">
-                                <input type="hidden" name="value" value="<?= (int) ($selectedDeck['offline_enabled'] ?? 0) ? 0 : 1 ?>">
-                                <label>Offline learning</label>
-                                <button class="switch <?= (int) ($selectedDeck['offline_enabled'] ?? 0) ? 'on' : '' ?>" type="submit" aria-pressed="<?= (int) ($selectedDeck['offline_enabled'] ?? 0) ? 'true' : 'false' ?>">
-                                    <span class="sr-only"><?= (int) ($selectedDeck['offline_enabled'] ?? 0) ? 'On' : 'Off' ?></span>
-                                </button>
-                            </form>
-                            <form method="post" action="index.php?a=toggle_deck_flag" class="toggle-row">
-                                <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
-                                <input type="hidden" name="deck_id" value="<?= (int) $selectedDeckId ?>">
-                                <input type="hidden" name="flag" value="is_reversed">
-                                <input type="hidden" name="value" value="<?= (int) ($selectedDeck['is_reversed'] ?? 0) ? 0 : 1 ?>">
-                                <label>Reverse cards</label>
-                                <button class="switch <?= (int) ($selectedDeck['is_reversed'] ?? 0) ? 'on' : '' ?>" type="submit" aria-pressed="<?= (int) ($selectedDeck['is_reversed'] ?? 0) ? 'true' : 'false' ?>">
-                                    <span class="sr-only"><?= (int) ($selectedDeck['is_reversed'] ?? 0) ? 'On' : 'Off' ?></span>
-                                </button>
-                            </form>
-                            <form method="post" action="index.php?a=toggle_deck_flag" class="toggle-row">
-                                <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
-                                <input type="hidden" name="deck_id" value="<?= (int) $selectedDeckId ?>">
-                                <input type="hidden" name="flag" value="is_frozen">
-                                <input type="hidden" name="value" value="<?= (int) ($selectedDeck['is_frozen'] ?? 0) ? 0 : 1 ?>">
-                                <label>Freeze deck</label>
-                                <button class="switch <?= (int) ($selectedDeck['is_frozen'] ?? 0) ? 'on' : '' ?>" type="submit" aria-pressed="<?= (int) ($selectedDeck['is_frozen'] ?? 0) ? 'true' : 'false' ?>">
-                                    <span class="sr-only"><?= (int) ($selectedDeck['is_frozen'] ?? 0) ? 'On' : 'Off' ?></span>
-                                </button>
-                            </form>
-                            <form method="post" action="index.php?a=toggle_deck_flag" class="toggle-row">
-                                <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
-                                <input type="hidden" name="deck_id" value="<?= (int) $selectedDeckId ?>">
-                                <input type="hidden" name="flag" value="tts_enabled">
-                                <input type="hidden" name="value" value="<?= (int) ($selectedDeck['tts_enabled'] ?? 0) ? 0 : 1 ?>">
-                                <label>Text-to-speech</label>
-                                <button class="switch <?= (int) ($selectedDeck['tts_enabled'] ?? 0) ? 'on' : '' ?>" type="submit" aria-pressed="<?= (int) ($selectedDeck['tts_enabled'] ?? 0) ? 'true' : 'false' ?>">
-                                    <span class="sr-only"><?= (int) ($selectedDeck['tts_enabled'] ?? 0) ? 'On' : 'Off' ?></span>
-                                </button>
-                            </form>
-                        </div>
-                    </div>
-
-                    <div class="deck-secondary-actions">
-                        <form method="post" action="index.php?a=select_deck">
-                            <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
-                            <input type="hidden" name="deck_id" value="<?= (int) $selectedDeckId ?>">
-                            <button class="btn ghost" type="submit">Select deck</button>
-                        </form>
-                        <form method="post" action="index.php?a=duplicate_deck">
-                            <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
-                            <input type="hidden" name="deck_id" value="<?= (int) $selectedDeckId ?>">
-                            <button class="btn ghost" type="submit">Duplicate deck</button>
-                        </form>
-                        <form method="post" action="index.php?a=move_deck">
-                            <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
-                            <input type="hidden" name="deck_id" value="<?= (int) $selectedDeckId ?>">
-                            <input type="hidden" name="category" value="Favorites">
-                            <button class="btn ghost" type="submit">Move to Favorites</button>
-                        </form>
-                        <form method="post" action="index.php?a=reset_deck_progress" onsubmit="return confirm('Reset progress for this deck?');">
-                            <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
-                            <input type="hidden" name="deck_id" value="<?= (int) $selectedDeckId ?>">
-                            <button class="btn ghost" type="submit">Reset progress</button>
-                        </form>
-                        <form method="post" action="index.php?a=archive_deck" onsubmit="return confirm('Archive this deck?');">
-                            <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
-                            <input type="hidden" name="deck_id" value="<?= (int) $selectedDeckId ?>">
-                            <button class="btn ghost" type="submit">Archive deck</button>
-                        </form>
-                        <a class="btn ghost" href="import_csv.php">Import cards</a>
-                    </div>
-
-                    <form class="publish-card" method="post" action="index.php?a=publish_deck">
-                        <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
-                        <input type="hidden" name="deck_id" value="<?= (int) $selectedDeckId ?>">
-                        <h4>Publish in library</h4>
-                        <p>Add a short description to share this deck publicly. You need at least <?= (int) ($selectedDeck['min_cards_required'] ?? 75) ?> cards.</p>
-                        <textarea name="publish_description" rows="2" placeholder="Enter text here (30 characters minimum)"></textarea>
-                        <button class="btn primary" type="submit">Submit for review</button>
-                    </form>
-
-                    <div class="deck-history" id="deck-history">
-                        <header>
-                            <h4>Learning history</h4>
-                            <p class="section-subtitle">Recent reviews with proficiency levels.</p>
-                        </header>
-                        <?php if ($deckHistory): ?>
-                            <ul>
-                                <?php foreach ($deckHistory as $row): ?>
-                                    <li>
-                                        <strong><?= h($row['hebrew']) ?></strong>
-                                        <span><?= h($row['transliteration']) ?></span>
-                                        <span class="badge">Level <?= (int) $row['proficiency'] ?></span>
-                                        <time><?= h($row['last_reviewed_at']) ?></time>
-                                    </li>
-                                <?php endforeach; ?>
-                            </ul>
-                        <?php else: ?>
-                            <p>No review history yet.</p>
-                        <?php endif; ?>
-                    </div>
-                </section>
-            <?php endif; ?>
-        </section>
-
-        <section class="screen" data-screen="settings" <?= $screen === 'settings' ? '' : 'hidden' ?>>
-            <section class="card settings-profile">
-                <div class="avatar" role="img" aria-label="Kristina Artemova avatar">K</div>
-                <div>
-                    <h2>Kristina Artemova</h2>
-                    <p>@kristinaartemova</p>
-                </div>
-                <button class="btn ghost" type="button" data-dialog-open="account">Manage account</button>
-            </section>
-
-            <section class="card settings-section">
-                <h3>General</h3>
-                <div class="settings-item">
-                    <div>
-                        <p>Appearance</p>
-                        <span>Switch between light and dark themes.</span>
-                    </div>
-                    <button class="btn ghost" data-theme-toggle>Auto</button>
-                </div>
-                <div class="settings-item">
-                    <div>
-                        <p>Language pack</p>
-                        <span>Install additional interface languages.</span>
-                    </div>
-                    <button class="btn ghost" type="button" data-dialog-open="language">Open language pack</button>
-                </div>
-                <div class="settings-item">
-                    <div>
-                        <p>App icon</p>
-                        <span>Choose an icon for your home screen.</span>
-                    </div>
-                    <button class="btn ghost" type="button" data-dialog-open="app-icon">Choose icon</button>
-                </div>
-            </section>
-
-            <section class="card settings-section">
-                <h3>Notifications & Feedback</h3>
-                <div class="settings-item">
-                    <div>
-                        <p>Reminders</p>
-                        <span>Receive notifications to study cards.</span>
-                    </div>
-                    <div class="settings-toggle">
-                        <button class="switch" data-toggle="reminders" aria-pressed="false" type="button">
-                            <span class="sr-only">Off</span>
-                        </button>
-                        <p class="settings-hint" data-reminders-message hidden></p>
-                    </div>
-
-                </div>
-                <div class="settings-item">
-                    <div>
-                        <p>Haptic feedback</p>
-                        <span>Vibrate on correct and incorrect answers.</span>
-                    </div>
-                    <div class="settings-toggle">
-                        <button class="switch" data-toggle="haptics" aria-pressed="false" type="button">
-                            <span class="sr-only">Off</span>
-                        </button>
-                        <p class="settings-hint" data-haptics-message hidden></p>
-                    </div>
-
-                </div>
-            </section>
-
-            <section class="card settings-section">
-                <h3>About</h3>
-                <div class="settings-item link">
-                    <span>What's new</span>
-                    <a href="docs/mobile-roadmap.md" target="_blank" rel="noopener noreferrer">View release notes</a>
-                </div>
-                <div class="settings-item link">
-                    <span>Help center</span>
-                    <a href="https://example.com/help" target="_blank" rel="noopener noreferrer">Open help center</a>
-                </div>
-                <div class="settings-item link">
-                    <span>Privacy policy</span>
-                    <a href="https://example.com/privacy" target="_blank" rel="noopener noreferrer">Read privacy policy</a>
-                </div>
-                <div class="settings-item link">
-                    <span>Terms of use</span>
-                    <a href="https://example.com/terms" target="_blank" rel="noopener noreferrer">Read terms of use</a>
-                </div>
-                <div class="settings-item link">
-                    <span>Send feedback</span>
-                    <a href="mailto:hello@example.com">Email feedback<span class="sr-only"> (opens your email client)</span></a>
-                </div>
-                <div class="settings-item link">
-                    <span>Rate us</span>
-                    <a href="https://example.com/app" target="_blank" rel="noopener noreferrer">Open app store page</a>
-                </div>
-            </section>
-
-            <section class="card settings-section">
-                <h3>Text-to-speech</h3>
-                <form method="post" action="index.php?a=update_tts" class="tts-form" data-tts-form>
-                    <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
-                    <input type="hidden" name="deck_id" value="<?= (int) $selectedDeckId ?>">
-                    <div class="settings-item">
-                        <div>
-                            <p>Front side language</p>
-                            <span>Choose the language of the prompt.</span>
-                        </div>
-                        <select name="front_lang" data-rtl-sensitive>
-                            <option value="en-US" <?= ($selectedDeck['tts_front_lang'] ?? '') === 'en-US' ? 'selected' : '' ?>>English (US)</option>
-                            <option value="en-GB" <?= ($selectedDeck['tts_front_lang'] ?? '') === 'en-GB' ? 'selected' : '' ?>>English (UK)</option>
-                            <option value="ru-RU" <?= ($selectedDeck['tts_front_lang'] ?? '') === 'ru-RU' ? 'selected' : '' ?>>Russian</option>
-                            <option value="he-IL" <?= ($selectedDeck['tts_front_lang'] ?? '') === 'he-IL' ? 'selected' : '' ?>>Hebrew</option>
-                        </select>
-                    </div>
-                    <div class="settings-item">
-                        <div>
-                            <p>Front side voice</p>
-                            <span>Select the available voice for the prompt.</span>
-                        </div>
-                        <select name="front_voice" data-voice-select="front" data-rtl-sensitive data-initial-voice="<?= h($selectedDeck['tts_front_voice'] ?? '') ?>">
-                            <option value="">System default</option>
-                        </select>
-                    </div>
-                    <div class="settings-item">
-                        <div>
-                            <p>Back side language</p>
-                            <span>Language used for answers.</span>
-                        </div>
-                        <select name="back_lang" data-rtl-sensitive>
-                            <option value="he-IL" <?= ($selectedDeck['tts_back_lang'] ?? '') === 'he-IL' ? 'selected' : '' ?>>Hebrew</option>
-                            <option value="en-US" <?= ($selectedDeck['tts_back_lang'] ?? '') === 'en-US' ? 'selected' : '' ?>>English (US)</option>
-                            <option value="ru-RU" <?= ($selectedDeck['tts_back_lang'] ?? '') === 'ru-RU' ? 'selected' : '' ?>>Russian</option>
-                        </select>
-                    </div>
-                    <div class="settings-item">
-                        <div>
-                            <p>Back side voice</p>
-                            <span>Voice used for answers.</span>
-                        </div>
-                        <select name="back_voice" data-voice-select="back" data-rtl-sensitive data-initial-voice="<?= h($selectedDeck['tts_back_voice'] ?? '') ?>">
-                            <option value="">System default</option>
-                        </select>
-                    </div>
-                    <p class="settings-hint" data-tts-support hidden></p>
-                    <button class="btn primary" type="submit" data-tts-submit disabled>Save TTS preferences</button>
-                </form>
-
-                <?php if ($deckSample): ?>
-                    <div class="tts-preview" data-tts-sample>
-                        <div class="tts-preview-card">
-                            <h4><?= h($deckSample['is_reversed'] ? ($deckSample['meaning'] ?? '') : ($deckSample['hebrew'] ?? '')) ?></h4>
-                            <p><?= h($deckSample['is_reversed'] ? ($deckSample['hebrew'] ?? '') : ($deckSample['meaning'] ?? '')) ?></p>
-                        </div>
-                        <button class="btn primary" type="button" data-tts-play>Play preview</button>
-                        <p class="settings-hint" data-tts-message hidden></p>
-                    </div>
-                <?php endif; ?>
-            </section>
-
-            <section class="card settings-section">
-                <h3>Follow us</h3>
-                <div class="social-row">
-                    <a href="https://instagram.com" class="social instagram" target="_blank" rel="noopener noreferrer">Instagram</a>
-                    <a href="https://youtube.com" class="social youtube" target="_blank" rel="noopener noreferrer">YouTube</a>
-                    <a href="https://facebook.com" class="social facebook" target="_blank" rel="noopener noreferrer">Facebook</a>
-                </div>
-                <p class="app-version">App version: 2.13.5 (1758135553)</p>
-            </section>
-        </section>
-    </main>
-
-    <nav class="bottom-nav" aria-label="Primary">
-        <a href="?screen=home" class="bottom-nav-item<?= $screen === 'home' ? ' active' : '' ?>" data-nav="home" <?= $screen === 'home' ? 'aria-current="page"' : '' ?>>Home</a>
-        <a href="?screen=library" class="bottom-nav-item<?= $screen === 'library' ? ' active' : '' ?>" data-nav="library" <?= $screen === 'library' ? 'aria-current="page"' : '' ?>>Library</a>
-        <a href="?screen=settings" class="bottom-nav-item<?= $screen === 'settings' ? ' active' : '' ?>" data-nav="settings" <?= $screen === 'settings' ? 'aria-current="page"' : '' ?>>Settings</a>
-
-    </nav>
-</div>
-
-<div class="deck-sheet" id="deck-sheet" role="dialog" aria-modal="true" aria-labelledby="deck-sheet-title" hidden>
-    <div class="deck-sheet-content" tabindex="-1">
-        <header>
-            <h4 id="deck-sheet-title">Deck actions</h4>
-            <button type="button" class="deck-sheet-close" data-deck-sheet-close aria-label="Close">Close</button>
         </header>
-        <div class="deck-sheet-actions">
-            <form method="post" action="index.php?a=select_deck">
-                <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
-                <input type="hidden" name="deck_id" value="">
-                <button class="sheet-action" type="submit">Select</button>
-            </form>
-            <form method="post" action="index.php?a=toggle_deck_flag" data-sheet-toggle="is_frozen">
-                <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
-                <input type="hidden" name="deck_id" value="">
-                <input type="hidden" name="flag" value="is_frozen">
-                <input type="hidden" name="value" value="1">
-                <button class="sheet-action" type="submit">Freeze</button>
-            </form>
-            <form method="post" action="index.php?a=move_deck">
-                <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
-                <input type="hidden" name="deck_id" value="">
-                <input type="hidden" name="category" value="General">
-                <button class="sheet-action" type="submit">Move</button>
-            </form>
-            <form method="post" action="index.php?a=toggle_deck_flag" data-sheet-toggle="is_reversed">
-                <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
-                <input type="hidden" name="deck_id" value="">
-                <input type="hidden" name="flag" value="is_reversed">
-                <input type="hidden" name="value" value="1">
-                <button class="sheet-action" type="submit">Reverse</button>
-            </form>
-            <form method="post" action="index.php?a=duplicate_deck">
-                <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
-                <input type="hidden" name="deck_id" value="">
-                <button class="sheet-action" type="submit">Duplicate</button>
-            </form>
-            <a class="sheet-action" href="?screen=library#deck-history">Learning history</a>
-            <form method="post" action="index.php?a=delete_deck" data-confirm-message="Delete this deck?">
-                <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
-                <input type="hidden" name="deck_id" value="">
-                <button class="sheet-action danger" type="submit">Delete</button>
-            </form>
-        </div>
-    </div>
+
+        <?php if ($flash): ?>
+            <div class="flash <?= h($flash['type'] ?? 'info') ?>" role="status">
+                <?= h($flash['message'] ?? '') ?>
+            </div>
+        <?php endif; ?>
+
+        <?php
+        $templateData = [
+            'csrf' => $csrf,
+            'selectedDeck' => $selectedDeck,
+            'selectedDeckId' => $selectedDeckId,
+            'decks' => $decks,
+            'dueSummary' => $dueSummary,
+            'sampleCard' => $sampleCard,
+            'recentHistory' => $recentHistory,
+            'starterPhrases' => $starterPhrases,
+        ];
+
+        $templatePath = __DIR__ . '/partials/' . $screen . '.php';
+        if (is_file($templatePath)) {
+            extract($templateData, EXTR_SKIP);
+            require $templatePath;
+        } else {
+            echo '<p class="empty-state">התוכן אינו זמין.</p>';
+        }
+        ?>
+    </main>
 </div>
-
-
-<div class="dialog" id="dialog-create-deck" role="dialog" aria-modal="true" aria-labelledby="dialog-create-deck-title" hidden>
-    <form class="dialog-content" method="post" action="index.php?a=create_deck" tabindex="-1">
-        <h3 id="dialog-create-deck-title">Create a new deck</h3>
-        <p>Organise cards by topic or difficulty for quick study sessions.</p>
-        <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
-        <label for="dialog-deck-name">Deck name</label>
-        <input id="dialog-deck-name" name="name" required>
-        <label for="dialog-deck-description">Description</label>
-        <textarea id="dialog-deck-description" name="description" rows="2" placeholder="e.g., Law terms"></textarea>
-        <label for="dialog-deck-category">Category</label>
-        <input id="dialog-deck-category" name="category" placeholder="Law, Geography, Math...">
-        <div class="dialog-actions">
-            <button type="button" class="btn ghost" data-dialog-close aria-label="Close dialog">Cancel</button>
-            <button type="submit" class="btn primary">Create</button>
-        </div>
-    </form>
-</div>
-
-<div class="dialog" id="dialog-language" role="dialog" aria-modal="true" aria-labelledby="dialog-language-title" aria-describedby="dialog-language-description" hidden>
-    <div class="dialog-content" tabindex="-1">
-        <h3 id="dialog-language-title">Language packs</h3>
-        <p id="dialog-language-description">Download and enable interface translations. Saved language is remembered for your next visit.</p>
-        <ul class="dialog-list">
-            <li><button type="button" class="btn ghost" data-set-ui-lang="en-US">English (US)</button></li>
-            <li><button type="button" class="btn ghost" data-set-ui-lang="he-IL">עברית (Hebrew)</button></li>
-        </ul>
-        <div class="dialog-actions">
-            <button type="button" class="btn primary" data-dialog-close>Done</button>
-        </div>
-    </div>
-</div>
-
-<div class="dialog" id="dialog-app-icon" role="dialog" aria-modal="true" aria-labelledby="dialog-app-icon-title" aria-describedby="dialog-app-icon-description" hidden>
-    <div class="dialog-content" tabindex="-1">
-        <h3 id="dialog-app-icon-title">Choose app icon</h3>
-        <p id="dialog-app-icon-description">Select the colour that fits your home screen best.</p>
-        <div class="dialog-grid" data-app-icon-picker>
-            <button type="button" class="icon-option" data-icon="sparkles">✨ Sparkles</button>
-            <button type="button" class="icon-option" data-icon="book">📘 Book</button>
-            <button type="button" class="icon-option" data-icon="compass">🧭 Compass</button>
-        </div>
-        <div class="dialog-actions">
-            <button type="button" class="btn ghost" data-dialog-close>Cancel</button>
-            <button type="button" class="btn primary" data-save-app-icon>Apply</button>
-        </div>
-    </div>
-</div>
-
-<div class="dialog" id="dialog-account" role="dialog" aria-modal="true" aria-labelledby="dialog-account-title" aria-describedby="dialog-account-description" hidden>
-    <div class="dialog-content" tabindex="-1">
-        <h3 id="dialog-account-title">Manage account</h3>
-        <p id="dialog-account-description">Update your profile details, change the password, or download your data export.</p>
-        <div class="dialog-actions">
-            <a class="btn ghost" href="logout.php">Sign out</a>
-            <a class="btn primary" href="register.php">Update profile</a>
-            <button type="button" class="btn ghost" data-dialog-close>Close</button>
-        </div>
-    </div>
-</div>
-
-<?php if (!empty($memoryData)): ?>
-    <script type="application/json" id="memory-data"><?= json_encode($memoryData, JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT) ?></script>
-<?php endif; ?>
-
-
-<script src="scripts/app-shell.js" defer></script>
-=
 </body>
 </html>

--- a/lib/dashboard_actions.php
+++ b/lib/dashboard_actions.php
@@ -50,6 +50,19 @@ function handle_dashboard_action(string $action, PDO $pdo, array $context): void
     }
 }
 
+function dashboard_redirect(string $defaultPath): void
+{
+    $candidate = $_POST['redirect'] ?? $_GET['redirect'] ?? null;
+    if (is_string($candidate)) {
+        $candidate = trim($candidate);
+        if ($candidate !== '' && !preg_match('#^(?:https?:)?//#', $candidate)) {
+            redirect($candidate);
+        }
+    }
+
+    redirect($defaultPath);
+}
+
 function handle_create_word_action(PDO $pdo, array $context): void
 {
     check_token($_POST['csrf'] ?? null);
@@ -211,7 +224,7 @@ function handle_create_deck_action(PDO $pdo): void
 
     if ($name === '') {
         flash('Deck name is required.', 'error');
-        redirect('index.php?screen=library');
+        dashboard_redirect('index.php?screen=library');
     }
 
     $palette = ['#6366f1', '#22d3ee', '#f97316', '#facc15', '#34d399', '#ec4899', '#0ea5e9', '#a855f7'];
@@ -235,7 +248,7 @@ function handle_create_deck_action(PDO $pdo): void
     $_SESSION['selected_deck'] = $newDeckId;
 
     flash('Deck created.', 'success');
-    redirect('index.php?screen=library');
+    dashboard_redirect('index.php?screen=library');
 }
 
 function handle_update_deck_details_action(PDO $pdo): void
@@ -249,14 +262,14 @@ function handle_update_deck_details_action(PDO $pdo): void
 
     if ($deckId <= 0 || $name === '') {
         flash('Unable to update deck.', 'error');
-        redirect('index.php?screen=library');
+        dashboard_redirect('index.php?screen=library');
     }
 
     $stmt = $pdo->prepare('UPDATE decks SET name = ?, description = ?, category = ? WHERE id = ?');
     $stmt->execute([$name, $description !== '' ? $description : null, $category, $deckId]);
 
     flash('Deck details updated.', 'success');
-    redirect('index.php?screen=library');
+    dashboard_redirect('index.php?screen=library');
 }
 
 function handle_move_deck_action(PDO $pdo): void
@@ -268,14 +281,14 @@ function handle_move_deck_action(PDO $pdo): void
 
     if ($deckId <= 0) {
         flash('Deck not found.', 'error');
-        redirect('index.php?screen=library');
+        dashboard_redirect('index.php?screen=library');
     }
 
     $stmt = $pdo->prepare('UPDATE decks SET category = ? WHERE id = ?');
     $stmt->execute([$category, $deckId]);
 
     flash('Deck moved to ' . $category . '.', 'success');
-    redirect('index.php?screen=library');
+    dashboard_redirect('index.php?screen=library');
 }
 
 function handle_select_deck_action(PDO $pdo): void
@@ -291,7 +304,7 @@ function handle_select_deck_action(PDO $pdo): void
     } else {
         flash('Deck not found.', 'error');
     }
-    redirect('index.php?screen=library');
+    dashboard_redirect('index.php?screen=library');
 }
 
 function handle_toggle_deck_flag_action(PDO $pdo): void
@@ -308,7 +321,7 @@ function handle_toggle_deck_flag_action(PDO $pdo): void
         flash('Unable to update deck preferences.', 'error');
     }
 
-    redirect('index.php?screen=library');
+    dashboard_redirect('index.php?screen=library');
 }
 
 function handle_duplicate_deck_action(PDO $pdo): void
@@ -324,7 +337,7 @@ function handle_duplicate_deck_action(PDO $pdo): void
         flash('Unable to duplicate deck.', 'error');
     }
 
-    redirect('index.php?screen=library');
+    dashboard_redirect('index.php?screen=library');
 }
 
 function handle_delete_deck_action(PDO $pdo, array $context): void
@@ -335,7 +348,7 @@ function handle_delete_deck_action(PDO $pdo, array $context): void
 
     if ($deckId <= 0) {
         flash('Deck not found.', 'error');
-        redirect('index.php?screen=library');
+        dashboard_redirect('index.php?screen=library');
     }
 
     $pdo->prepare('DELETE FROM decks WHERE id = ?')->execute([$deckId]);
@@ -344,7 +357,7 @@ function handle_delete_deck_action(PDO $pdo, array $context): void
     }
 
     flash('Deck deleted.', 'success');
-    redirect('index.php?screen=library');
+    dashboard_redirect('index.php?screen=library');
 }
 
 function handle_publish_deck_action(PDO $pdo): void
@@ -366,14 +379,14 @@ function handle_publish_deck_action(PDO $pdo): void
 
     if ($cardsCount < $minRequired) {
         flash(sprintf('Add %d more cards before publishing.', $minRequired - $cardsCount), 'error');
-        redirect('index.php?screen=library');
+        dashboard_redirect('index.php?screen=library');
     }
 
     $pdo->prepare('UPDATE decks SET published_at = NOW(), published_description = ? WHERE id = ?')
         ->execute([$description !== '' ? $description : null, $deckId]);
 
     flash('Deck submitted to the community library.', 'success');
-    redirect('index.php?screen=library');
+    dashboard_redirect('index.php?screen=library');
 }
 
 function handle_update_tts_action(PDO $pdo): void
@@ -389,7 +402,7 @@ function handle_update_tts_action(PDO $pdo): void
     $stmt->execute([$frontLang, $backLang, $frontVoice, $backVoice, $deckId]);
 
     flash('העדפות TTS נשמרו.', 'success');
-    redirect('index.php?screen=settings');
+    dashboard_redirect('index.php?screen=settings');
 }
 
 function handle_reset_deck_progress_action(PDO $pdo, array $context): void
@@ -406,7 +419,7 @@ function handle_reset_deck_progress_action(PDO $pdo, array $context): void
     $delete->execute([$userIdentifier, $deckId]);
 
     flash('Progress reset for this deck.', 'success');
-    redirect('index.php?screen=library');
+    dashboard_redirect('index.php?screen=library');
 }
 
 function handle_archive_deck_action(PDO $pdo): void
@@ -418,5 +431,5 @@ function handle_archive_deck_action(PDO $pdo): void
     $stmt->execute(['Archived', $deckId]);
 
     flash('Deck archived.', 'success');
-    redirect('index.php?screen=library');
+    dashboard_redirect('index.php?screen=library');
 }

--- a/partials/home.php
+++ b/partials/home.php
@@ -1,0 +1,117 @@
+<section class="panel hero">
+    <div class="hero__content">
+        <h3>לימוד חכם ומרוכז</h3>
+        <p>
+            Noji הראתה כמה פשוט יכול להיות שינון יעיל: כרטיס אחד בכל פעם, משוב קצר,
+            וקצב שמותאם אליך. הבית המרכזי מציג את הסטטוס היומי ומאפשר לצלול מיד לתרגול.
+        </p>
+        <dl class="hero-metrics">
+            <div>
+                <dt>כרטיסים לתרגול היום</dt>
+                <dd><?= $dueSummary['deck'] !== null ? (int) $dueSummary['deck'] : '—' ?></dd>
+            </div>
+            <div>
+                <dt>כרטיסים בכל הסטים</dt>
+                <dd><?= $dueSummary['total'] !== null ? (int) $dueSummary['total'] : '—' ?></dd>
+            </div>
+            <?php if ($selectedDeck): ?>
+                <div>
+                    <dt>התקדמות ב-<?= h($selectedDeck['name']) ?></dt>
+                    <dd><?= (int) ($selectedDeck['progress_percent'] ?? 0) ?>%</dd>
+                </div>
+            <?php endif; ?>
+        </dl>
+        <div class="hero-actions">
+            <?php if ($selectedDeckId > 0): ?>
+                <a class="btn primary" href="study.php?deck=<?= (int) $selectedDeckId ?>">התחלת סשן</a>
+            <?php else: ?>
+                <a class="btn primary" href="study.php">התחלת סשן</a>
+            <?php endif; ?>
+            <a class="btn ghost" href="study.php">תרגול חופשי</a>
+            <?php if ($selectedDeckId > 0): ?>
+                <form method="post" action="index.php?screen=home&amp;a=seed_openers" class="inline-form">
+                    <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
+                    <input type="hidden" name="deck_id" value="<?= (int) $selectedDeckId ?>">
+                    <button type="submit" class="btn ghost">הוספת משפטי פתיחה</button>
+                </form>
+            <?php endif; ?>
+        </div>
+    </div>
+    <div class="hero__visual" aria-hidden="true">
+        <div class="hero-bubble">🗂️</div>
+        <p>החזרות נבנות סביב הרגע שבו כמעט שוכחים — בדיוק כמו ב-Noji.</p>
+    </div>
+</section>
+
+<?php if ($sampleCard): ?>
+<section class="panel sample-card" aria-labelledby="sample-card-title">
+    <div class="panel-header">
+        <div>
+            <h3 id="sample-card-title">טעימה מהכרטיס הבא</h3>
+            <p class="panel-subtitle">ככה תראה הכרטיסיה שלך בלמידה. צד אחד עברית, צד שני משמעות.</p>
+        </div>
+        <a class="btn ghost" href="words.php">ניהול אוצר מילים</a>
+    </div>
+    <div class="sample-card__body">
+        <div class="sample-card__word">
+            <span class="sample-card__label">עברית</span>
+            <strong dir="rtl"><?= h($sampleCard['hebrew'] ?? '—') ?></strong>
+            <?php if (!empty($sampleCard['transliteration'])): ?>
+                <span class="sample-card__translit" dir="ltr"><?= h($sampleCard['transliteration']) ?></span>
+            <?php endif; ?>
+        </div>
+        <div class="sample-card__meaning">
+            <span class="sample-card__label">משמעות</span>
+            <p><?= h($sampleCard['meaning'] ?? 'אין תרגום שמור עדיין') ?></p>
+            <?php if (!empty($sampleCard['other_script'])): ?>
+                <p class="sample-card__alt"><?= h($sampleCard['other_script']) ?></p>
+            <?php endif; ?>
+        </div>
+    </div>
+</section>
+<?php endif; ?>
+
+<section class="panel panel--form" aria-labelledby="quick-add-title">
+    <h3 id="quick-add-title">הוספת כרטיס חדש</h3>
+    <p class="panel-subtitle">שמור/י מילה או ביטוי חדש ישירות ל-Deck הנוכחי. ההוספה פשוטה ומהירה.</p>
+    <form method="post" action="index.php?screen=home&amp;a=create_word" class="stacked-form">
+        <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
+        <input type="hidden" name="deck_id" value="<?= (int) $selectedDeckId ?>">
+        <input type="hidden" name="lang_code" value="en">
+        <label for="hebrew-input">עברית</label>
+        <input id="hebrew-input" name="hebrew" required placeholder="לדוגמה: מה שלומך?">
+
+        <label for="translit-input">תעתיק (לא חובה)</label>
+        <input id="translit-input" name="transliteration" placeholder="ma shlomkha?">
+
+        <label for="meaning-input">משמעות / תרגום</label>
+        <input id="meaning-input" name="meaning" placeholder="How are you?">
+
+        <label for="notes-input">הערות (לא חובה)</label>
+        <textarea id="notes-input" name="notes" rows="3" placeholder="הקשר, דוגמאות או טיפים לזכירה"></textarea>
+
+        <button type="submit" class="btn primary">שמירה לכרטיסיות</button>
+    </form>
+</section>
+
+<?php if ($recentHistory): ?>
+<section class="panel" aria-labelledby="history-title">
+    <h3 id="history-title">מה תרגלת לאחרונה</h3>
+    <ul class="history-list">
+        <?php foreach ($recentHistory as $entry): ?>
+            <li>
+                <div>
+                    <strong dir="rtl"><?= h($entry['hebrew']) ?></strong>
+                    <?php if (!empty($entry['transliteration'])): ?>
+                        <span class="history-translit" dir="ltr"><?= h($entry['transliteration']) ?></span>
+                    <?php endif; ?>
+                </div>
+                <span class="history-meta">
+                    <?= h($entry['last_reviewed_at'] ? date('d.m.Y H:i', strtotime($entry['last_reviewed_at'])) : '—') ?> ·
+                    <?= h($entry['proficiency'] !== null ? 'רמה ' . $entry['proficiency'] : 'חזרה ראשונה') ?>
+                </span>
+            </li>
+        <?php endforeach; ?>
+    </ul>
+</section>
+<?php endif; ?>

--- a/partials/library.php
+++ b/partials/library.php
@@ -1,0 +1,73 @@
+<section class="panel panel--form" aria-labelledby="create-deck-title">
+    <h3 id="create-deck-title">יצירת Deck חדש</h3>
+    <p class="panel-subtitle">ארגנו מילים בקבוצות קטנות. כל Deck מתמקד בנושא מסוים כמו נסיעות, שיחות יומיומיות או דקדוק.</p>
+    <form method="post" action="index.php?screen=library&amp;a=create_deck" class="stacked-form">
+        <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
+        <label for="deck-name">שם Deck</label>
+        <input id="deck-name" name="name" required placeholder="לדוגמה: שיחות מסעדה">
+
+        <label for="deck-category">קטגוריה</label>
+        <input id="deck-category" name="category" placeholder="תחבורה, עבודה, משפחה...">
+
+        <label for="deck-description">תיאור קצר</label>
+        <textarea id="deck-description" name="description" rows="2" placeholder="מה נלמד ב-Deck הזה?"></textarea>
+
+        <button type="submit" class="btn primary">צור Deck</button>
+    </form>
+</section>
+
+<section class="panel" aria-labelledby="deck-list-title">
+    <div class="panel-header">
+        <div>
+            <h3 id="deck-list-title">הספריה האישית</h3>
+            <p class="panel-subtitle">בחרו Deck כדי להתחיל ללמוד או לעדכן אותו. המדדים מסבירים מה מצבכם ביחס לכל Deck.</p>
+        </div>
+        <a class="btn ghost" href="decks.php">ניהול מתקדם</a>
+    </div>
+
+    <?php if (!$decks): ?>
+        <p class="empty-state">עוד לא יצרתם Deck. התחילו עם אחד חדש ותוסיפו אליו כרטיסיות.</p>
+    <?php else: ?>
+        <div class="deck-list">
+            <?php foreach ($decks as $deck): ?>
+                <article class="deck-card<?= $deck['id'] == $selectedDeckId ? ' is-selected' : '' ?>">
+                    <header>
+                        <h4><?= h($deck['name']) ?></h4>
+                        <?php if (!empty($deck['description'])): ?>
+                            <p class="deck-card__description"><?= h($deck['description']) ?></p>
+                        <?php endif; ?>
+                    </header>
+                    <dl class="deck-card__stats">
+                        <div>
+                            <dt>כרטיסים</dt>
+                            <dd><?= (int) ($deck['cards_count'] ?? 0) ?></dd>
+                        </div>
+                        <div>
+                            <dt>נלמדו</dt>
+                            <dd><?= (int) ($deck['studied_count'] ?? 0) ?></dd>
+                        </div>
+                        <div>
+                            <dt>שולטים</dt>
+                            <dd><?= (int) ($deck['mastered_count'] ?? 0) ?></dd>
+                        </div>
+                        <div>
+                            <dt>התקדמות</dt>
+                            <dd><?= (int) ($deck['progress_percent'] ?? 0) ?>%</dd>
+                        </div>
+                    </dl>
+                    <footer class="deck-card__actions">
+                        <a class="btn primary" href="study.php?deck=<?= (int) $deck['id'] ?>">למידה</a>
+                        <a class="btn ghost" href="index.php?screen=<?= h($screen) ?>&amp;deck=<?= (int) $deck['id'] ?>">הפוך לפעיל</a>
+                        <a class="btn ghost" href="words.php?deck=<?= (int) $deck['id'] ?>">כרטיסיות</a>
+                    </footer>
+                    <?php if (!empty($deck['last_reviewed_at'])): ?>
+                        <?php $lastReviewedTs = strtotime((string) $deck['last_reviewed_at']); ?>
+                        <p class="deck-card__meta">
+                            חזרה אחרונה: <?= $lastReviewedTs ? h(date('d.m.Y', $lastReviewedTs)) : '—' ?>
+                        </p>
+                    <?php endif; ?>
+                </article>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+</section>

--- a/partials/settings.php
+++ b/partials/settings.php
@@ -1,0 +1,77 @@
+<?php if (!$selectedDeck): ?>
+<section class="panel">
+    <h3>אין Deck פעיל</h3>
+    <p class="panel-subtitle">צרו Deck חדש בספריה או בחרו אחד קיים כדי לערוך הגדרות מותאמות אישית.</p>
+    <a class="btn primary" href="index.php?screen=library">לספריה</a>
+</section>
+<?php else: ?>
+<section class="panel panel--form" aria-labelledby="deck-details-title">
+    <h3 id="deck-details-title">עדכון Deck</h3>
+    <p class="panel-subtitle">שנו את שם ה-Deck, התיאור או הקטגוריה שלו. זה מסייע להישאר מסודרים כמו ב-Noji.</p>
+    <form method="post" action="index.php?screen=settings&amp;a=update_deck_details" class="stacked-form">
+        <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
+        <input type="hidden" name="deck_id" value="<?= (int) $selectedDeckId ?>">
+        <input type="hidden" name="redirect" value="index.php?screen=settings">
+
+        <label for="settings-name">שם Deck</label>
+        <input id="settings-name" name="name" required value="<?= h($selectedDeck['name']) ?>">
+
+        <label for="settings-category">קטגוריה</label>
+        <input id="settings-category" name="category" value="<?= h($selectedDeck['category'] ?? '') ?>">
+
+        <label for="settings-description">תיאור</label>
+        <textarea id="settings-description" name="description" rows="3"><?= h($selectedDeck['description'] ?? '') ?></textarea>
+
+        <button type="submit" class="btn primary">שמירה</button>
+    </form>
+</section>
+
+<section class="panel" aria-labelledby="preferences-title">
+    <h3 id="preferences-title">העדפות Deck</h3>
+    <p class="panel-subtitle">פעילויות וחוויית לימוד שמתאימות לרמת השליטה שלכם.</p>
+    <div class="toggle-grid">
+        <form method="post" action="index.php?screen=settings&amp;a=toggle_deck_flag" class="toggle-card">
+            <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
+            <input type="hidden" name="deck_id" value="<?= (int) $selectedDeckId ?>">
+            <input type="hidden" name="flag" value="is_reversed">
+            <input type="hidden" name="value" value="<?= (int) ($selectedDeck['is_reversed'] ?? 0) === 1 ? 0 : 1 ?>">
+            <input type="hidden" name="redirect" value="index.php?screen=settings">
+            <h4>היפוך כרטיסים</h4>
+            <p>למדו מהתרגום לעברית ולהפך כדי לשפר שליפה דו-כיוונית.</p>
+            <button type="submit" class="toggle-button<?= (int) ($selectedDeck['is_reversed'] ?? 0) === 1 ? ' is-on' : '' ?>">
+                <?= (int) ($selectedDeck['is_reversed'] ?? 0) === 1 ? 'מופעל' : 'כבוי' ?>
+            </button>
+        </form>
+
+        <form method="post" action="index.php?screen=settings&amp;a=toggle_deck_flag" class="toggle-card">
+            <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
+            <input type="hidden" name="deck_id" value="<?= (int) $selectedDeckId ?>">
+            <input type="hidden" name="flag" value="tts_enabled">
+            <input type="hidden" name="value" value="<?= (int) ($selectedDeck['tts_enabled'] ?? 0) === 1 ? 0 : 1 ?>">
+            <input type="hidden" name="redirect" value="index.php?screen=settings">
+            <h4>קריינות (TTS)</h4>
+            <p>השמעת הכרטיס בזמן הלימוד מחזקת את הזיכרון השמיעתי.</p>
+            <button type="submit" class="toggle-button<?= (int) ($selectedDeck['tts_enabled'] ?? 0) === 1 ? ' is-on' : '' ?>">
+                <?= (int) ($selectedDeck['tts_enabled'] ?? 0) === 1 ? 'מופעל' : 'כבוי' ?>
+            </button>
+        </form>
+
+        <form method="post" action="index.php?screen=settings&amp;a=duplicate_deck" class="toggle-card">
+            <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
+            <input type="hidden" name="deck_id" value="<?= (int) $selectedDeckId ?>">
+            <input type="hidden" name="redirect" value="index.php?screen=settings">
+            <h4>שכפול Deck</h4>
+            <p>צרו עותק לעבודה נפרדת בלי לפגוע במקור.</p>
+            <button type="submit" class="toggle-button">שכפול</button>
+        </form>
+
+        <form method="post" action="index.php?screen=settings&amp;a=delete_deck" class="toggle-card" onsubmit="return confirm('למחוק את ה-Deck? לא ניתן לבטל.');">
+            <input type="hidden" name="csrf" value="<?= h($csrf) ?>">
+            <input type="hidden" name="deck_id" value="<?= (int) $selectedDeckId ?>">
+            <h4>מחיקת Deck</h4>
+            <p>מסירים לגמרי את הקבוצה הזו ואת שיוכי הכרטיסים.</p>
+            <button type="submit" class="toggle-button danger">מחיקה</button>
+        </form>
+    </div>
+</section>
+<?php endif; ?>

--- a/styles.css
+++ b/styles.css
@@ -1,80 +1,29 @@
 :root {
-    --bg: #f4f6fb;
+    --bg: #f5f7ff;
+    --bg-accent: linear-gradient(145deg, #eef2ff, #f8fafc);
     --card: #ffffff;
-    --card-muted: #f8fafc;
+    --card-muted: #f1f5f9;
     --text: #1e293b;
     --muted: #64748b;
-    --accent: #3b82f6;
-    --accent-soft: #dbeafe;
-    --accent-dark: #1d4ed8;
+    --accent: #6366f1;
+    --accent-dark: #4338ca;
     --border: #e2e8f0;
-    --shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
+    --shadow-soft: 0 20px 45px rgba(15, 23, 42, 0.12);
+    --shadow-card: 0 12px 24px rgba(15, 23, 42, 0.1);
     --success: #16a34a;
     --danger: #ef4444;
 }
 
-* {
+*, *::before, *::after {
     box-sizing: border-box;
 }
 
 body {
     margin: 0;
-    background: var(--bg);
+    font: 16px/1.6 "Inter", "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
     color: var(--text);
-    font: 16px/1.5 "Inter", "Segoe UI", -apple-system, BlinkMacSystemFont, sans-serif;
+    background: var(--bg-accent);
 }
-
-.sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-}
-
-.toast-region {
-    position: fixed;
-    inset-inline: 0;
-    top: 1rem;
-    display: flex;
-    justify-content: center;
-    pointer-events: none;
-    z-index: 1000;
-}
-
-.toast {
-    background: #111827;
-    color: #fff;
-    padding: 0.75rem 1.25rem;
-    border-radius: 999px;
-    box-shadow: 0 14px 32px rgba(15, 23, 42, 0.25);
-    font-weight: 500;
-    pointer-events: auto;
-    transition: opacity 0.2s ease, transform 0.2s ease;
-}
-
-.toast[hidden] {
-    opacity: 0;
-    transform: translateY(-20px);
-    visibility: hidden;
-}
-
-.toast-success {
-    background: var(--success);
-}
-
-.toast-error {
-    background: var(--danger);
-}
-
-.toast-info {
-    background: #1e3a8a;
-}
-
 
 a {
     color: var(--accent);
@@ -93,422 +42,107 @@ textarea {
     font: inherit;
 }
 
-.app-shell {
-    min-height: 100vh;
-    max-width: 1100px;
-    margin: 0 auto;
-    padding: 24px 24px 80px;
-}
-
-.app-header {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 20px;
-    margin-bottom: 24px;
-}
-
-.header-main h1 {
-    margin: 0 0 4px;
-    font-size: 28px;
-}
-
-.header-sub {
-    margin: 0;
-    color: var(--muted);
-}
-
-.search-form {
-    display: flex;
-    gap: 12px;
-    background: var(--card);
-    border-radius: 16px;
-    padding: 12px;
-    border: 1px solid var(--border);
-    box-shadow: var(--shadow);
-}
-
-.search-form input[type="text"] {
-    border: none;
-    border-radius: 12px;
-    padding: 10px 14px;
-    background: var(--card-muted);
-    min-width: 220px;
-}
-
 .btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 6px;
+    gap: 0.5rem;
+    padding: 0.65rem 1.35rem;
     border: none;
-    border-radius: 12px;
-    padding: 10px 18px;
-    cursor: pointer;
+    border-radius: 999px;
     font-weight: 600;
-    transition: transform 0.15s ease, box-shadow 0.15s ease;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    background: var(--card-muted);
+    color: var(--text);
+    box-shadow: inset 0 0 0 1px var(--border);
+}
+
+.btn:hover,
+.btn:focus-visible {
+    transform: translateY(-1px);
+    text-decoration: none;
+}
+
+.btn:active {
+    transform: translateY(0);
 }
 
 .btn:disabled,
 .btn[disabled] {
     opacity: 0.6;
     cursor: not-allowed;
-    box-shadow: none;
     transform: none;
+    box-shadow: none;
 }
 
 .btn.primary {
     background: linear-gradient(135deg, var(--accent), var(--accent-dark));
     color: #fff;
-    box-shadow: 0 12px 24px rgba(59, 130, 246, 0.35);
+    box-shadow: 0 18px 32px rgba(99, 102, 241, 0.32);
 }
 
 .btn.ghost {
-    background: var(--card-muted);
-    color: var(--text);
-    border: 1px solid var(--border);
+    background: rgba(99, 102, 241, 0.08);
+    color: var(--accent-dark);
 }
 
-.btn.danger {
+.btn.secondary {
+    background: var(--card-muted);
+}
+
+.btn.danger,
+.toggle-button.danger {
     background: var(--danger);
     color: #fff;
-}
-
-.btn:hover {
-    transform: translateY(-1px);
-}
-
-.btn:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
-    transform: translateY(-1px);
-}
-
-.btn:active {
-    transform: translateY(1px);
-}
-
-.btn:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-    box-shadow: none;
-    transform: none;
+    box-shadow: 0 12px 24px rgba(239, 68, 68, 0.28);
 }
 
 .flash {
-    background: var(--card);
-    border-radius: 12px;
-    border: 1px solid var(--border);
-    padding: 14px 18px;
-    margin-bottom: 20px;
-    box-shadow: var(--shadow);
-}
-
-.toast {
-    position: fixed;
-    left: 50%;
-    bottom: 90px;
-    transform: translate(-50%, 20px);
-    min-width: 240px;
-    max-width: 90vw;
-    background: var(--card);
-    border-radius: 14px;
-    border: 1px solid var(--border);
-    padding: 12px 18px;
-    box-shadow: var(--shadow);
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.25s ease, transform 0.25s ease;
-    z-index: 1000;
-}
-
-.toast-show {
-    opacity: 1;
-    transform: translate(-50%, 0);
-}
-
-.toast-hide {
-    opacity: 0;
-    transform: translate(-50%, 20px);
-}
-
-.toast-success {
-    border-color: rgba(22, 163, 74, 0.4);
-    background: rgba(34, 197, 94, 0.15);
-}
-
-.toast-error {
-    border-color: rgba(239, 68, 68, 0.4);
-    background: rgba(239, 68, 68, 0.15);
-}
-
-.toast-info {
-    border-color: rgba(59, 130, 246, 0.4);
-    background: rgba(59, 130, 246, 0.12);
+    margin-bottom: 1.5rem;
+    padding: 0.85rem 1.2rem;
+    border-radius: 1rem;
+    background: rgba(99, 102, 241, 0.12);
+    color: var(--accent-dark);
+    border: 1px solid rgba(99, 102, 241, 0.32);
 }
 
 .flash.success {
-    border-color: rgba(22, 163, 74, 0.35);
-    background: rgba(34, 197, 94, 0.15);
+    background: rgba(22, 163, 74, 0.12);
+    border-color: rgba(22, 163, 74, 0.32);
+    color: var(--success);
 }
 
 .flash.error {
-    border-color: rgba(239, 68, 68, 0.35);
-    background: rgba(239, 68, 68, 0.18);
+    background: rgba(239, 68, 68, 0.12);
+    border-color: rgba(239, 68, 68, 0.32);
+    color: var(--danger);
 }
 
-.card {
-    background: var(--card);
-    border-radius: 24px;
-    border: 1px solid var(--border);
-    padding: 24px;
-    margin-bottom: 24px;
-    box-shadow: var(--shadow);
-}
-
-.hero-card {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: 24px;
-    align-items: center;
-    background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(14, 165, 233, 0.1));
-}
-
-.hero-info h2 {
-    margin: 0;
-    font-size: 26px;
-}
-
-.hero-info p {
-    margin: 8px 0 18px;
-    color: var(--muted);
-}
-
-.hero-stats {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 16px;
-    margin-bottom: 18px;
-    color: var(--accent-dark);
-    font-weight: 600;
-}
-
-.hero-actions {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-}
-
-.hero-illustration {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.deck-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 48px;
-    width: 120px;
-    height: 120px;
-    border-radius: 32px;
-    background: var(--card);
-    border: 1px dashed var(--accent);
-}
-
-.section-heading {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 16px;
-    flex-wrap: wrap;
-}
-
-.section-subtitle {
-    margin: 4px 0 0;
-    color: var(--muted);
-    font-size: 14px;
-}
-
-.tag-group {
-    display: flex;
-    gap: 10px;
-    flex-wrap: wrap;
-}
-
-.tag-group select {
-    padding: 10px 14px;
-    border-radius: 12px;
-    border: 1px solid var(--border);
-    background: var(--card);
-    min-width: 160px;
-    color: var(--text);
-}
-
-.tag-group select:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
-}
-
-.flashcard-track {
-    display: flex;
-    gap: 16px;
-    overflow-x: auto;
-    padding-bottom: 12px;
-    scroll-snap-type: x mandatory;
-}
-
-.flashcard-track::-webkit-scrollbar {
-    height: 6px;
-}
-
-.flashcard-track::-webkit-scrollbar-thumb {
-    background: rgba(15, 23, 42, 0.2);
-    border-radius: 999px;
-}
-
-.flashcard {
-    flex: 0 0 280px;
-    background: var(--card-muted);
-    border-radius: 20px;
-    padding: 20px;
-    scroll-snap-align: start;
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    border: 1px solid rgba(148, 163, 184, 0.3);
-}
-
-.flashcard-header {
-    display: flex;
-    gap: 8px;
-    align-items: center;
-}
-
-.flashcard-text {
-    margin: 4px 0;
-    font-size: 15px;
-    line-height: 1.4;
-}
-
-.flashcard-translation {
-    margin-top: auto;
-    padding-top: 12px;
-    border-top: 1px solid rgba(148, 163, 184, 0.35);
-}
-
-.badge {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    background: rgba(59, 130, 246, 0.12);
-    color: var(--accent-dark);
-    border-radius: 999px;
-    padding: 2px 10px;
-    font-size: 12px;
-    font-weight: 600;
-}
-
-.badge-muted {
-    background: rgba(15, 23, 42, 0.08);
-    color: var(--text);
-}
-
-.badge-active {
-    background: rgba(16, 185, 129, 0.15);
-    color: #047857;
-}
-
-.hebrew-word {
-    margin: 0.2em 0;
-    font-size: 40px;
-    font-weight: 700;
-}
-
-.alt-script {
-    color: var(--muted);
-    font-size: 14px;
-}
-
-.example {
-    font-size: 14px;
-    color: var(--muted);
-}
-
-.memory-section {
-    border: 1px solid rgba(148, 163, 184, 0.35);
-}
-
-.memory-status {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 12px;
-    margin-bottom: 12px;
-    font-size: 14px;
-}
-
-.memory-board {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    gap: 12px;
-}
-
-.memory-card {
-    background: var(--card-muted);
-    border: 1px solid rgba(148, 163, 184, 0.35);
-    border-radius: 16px;
-    min-height: 100px;
-    display: grid;
-    place-items: center;
-    font-weight: 600;
-    font-size: 18px;
-    cursor: pointer;
-    transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
-}
-
-.memory-card span {
-    pointer-events: none;
-}
-
-.memory-card:hover,
-.memory-card:focus-visible {
-    transform: translateY(-2px);
-    border-color: var(--accent);
-}
-
-.memory-card.flipped {
-    background: var(--accent-soft);
-    border-color: var(--accent);
-}
-
-.memory-card.matched {
-    background: rgba(34, 197, 94, 0.15);
-    border-color: rgba(34, 197, 94, 0.45);
-    color: #15803d;
-    cursor: default;
-}
-
-.memory-empty {
-    color: var(--muted);
-}
-
-.seed-form {
-    margin-top: 12px;
+.flash.info {
+    background: rgba(14, 165, 233, 0.12);
+    border-color: rgba(14, 165, 233, 0.3);
+    color: #0e7490;
 }
 
 input,
 select,
 textarea {
     width: 100%;
-    border-radius: 12px;
+    padding: 0.7rem 0.85rem;
+    border-radius: 0.9rem;
     border: 1px solid var(--border);
-    padding: 10px 14px;
     background: var(--card-muted);
     color: var(--text);
+    transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+    outline: none;
+    border-color: rgba(99, 102, 241, 0.8);
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
 }
 
 textarea {
@@ -517,733 +151,672 @@ textarea {
 
 label {
     display: block;
-    margin: 14px 0 6px;
-    color: var(--muted);
+    margin-bottom: 0.35rem;
     font-weight: 600;
-}
-
-.form-actions {
-    margin-top: 16px;
-}
-
-.grid {
-    display: grid;
-    gap: 16px;
-}
-
-.grid-3 {
-    grid-template-columns: repeat(3, 1fr);
-}
-
-.grid.responsive {
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-}
-
-.record-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-    align-items: center;
-}
-
-.record-row input[type="file"] {
-    flex: 1 1 220px;
-}
-
-.record-controls {
-    display: flex;
-    gap: 10px;
-    flex-wrap: wrap;
-}
-
-.record-support {
-    margin-top: 6px;
     color: var(--muted);
-    font-size: 14px;
 }
 
-.record-preview {
+body.app-body {
+    min-height: 100vh;
     display: flex;
-    gap: 12px;
     align-items: center;
-    margin-top: 10px;
+    justify-content: center;
+    padding: 3rem 1.5rem;
 }
 
-.table {
-    width: 100%;
-    border-collapse: collapse;
-}
-
-.table th,
-.table td {
-    padding: 12px 10px;
-    border-bottom: 1px solid var(--border);
-    text-align: left;
-    vertical-align: top;
-    font-size: 15px;
-}
-
-.translations-pre {
-    margin: 0;
-    white-space: pre-wrap;
-    font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-}
-
-.library-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 16px;
-}
-
-.filter-bar {
-    display: flex;
-    gap: 10px;
-    flex-wrap: wrap;
-    margin: 16px 0 24px;
-}
-
-.filter-btn {
-    border: none;
-    background: var(--card-muted);
-    border-radius: 999px;
-    padding: 8px 18px;
-    cursor: pointer;
-    color: var(--muted);
-    font-weight: 600;
-}
-
-.filter-btn.active {
-    background: var(--accent);
-    color: #fff;
-}
-
-.deck-grid {
-    display: grid;
-    gap: 20px;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-}
-
-.deck-card {
+.app-container {
+    width: min(1100px, 100%);
     background: var(--card);
-    border-radius: 20px;
-    padding: 20px;
-    border: 1px solid var(--border);
-    box-shadow: var(--shadow);
-    position: relative;
+    border-radius: 2.5rem;
+    box-shadow: var(--shadow-soft);
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    gap: 2.5rem;
+    padding: 3rem;
 }
 
-.deck-card-header {
+.app-sidebar {
+    background: linear-gradient(165deg, rgba(99, 102, 241, 0.08), rgba(14, 165, 233, 0.06));
+    border-radius: 2rem;
+    padding: 2.25rem 1.75rem;
     display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 12px;
+    flex-direction: column;
+    gap: 2.5rem;
 }
 
-.deck-card-icon {
-    width: 46px;
-    height: 46px;
-    border-radius: 16px;
-    background: var(--accent-soft);
+.brand-block h1 {
+    margin: 0.2rem 0;
+    font-size: 1.65rem;
+}
+
+.brand-block p {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+.brand-icon {
+    width: 3rem;
+    height: 3rem;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-size: 24px;
-}
-
-.deck-card-menu {
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    font-size: 20px;
-    color: var(--muted);
-}
-
-.deck-card-desc {
-    color: var(--muted);
-    min-height: 42px;
-}
-
-.deck-card-stats {
-    display: grid;
-    grid-template-columns: repeat(3, auto);
-    gap: 16px;
-    margin: 16px 0;
-    color: var(--muted);
-}
-
-.deck-card-stats dt {
-    font-size: 12px;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-}
-
-.deck-card-progress {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    font-size: 13px;
-    color: var(--muted);
-}
-
-.progress-bar {
-    flex: 1;
-    height: 6px;
-    background: var(--card-muted);
-    border-radius: 999px;
-    overflow: hidden;
-}
-
-.progress-bar span {
-    display: block;
-    height: 100%;
-    background: var(--accent);
-    border-radius: inherit;
-}
-
-.deck-detail {
-    background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(16, 185, 129, 0.08));
-}
-
-.deck-settings-grid {
-    display: grid;
-    gap: 20px;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    margin-bottom: 24px;
-}
-
-.deck-form {
-    background: var(--card);
-    border-radius: 20px;
-    padding: 20px;
-    border: 1px solid rgba(148, 163, 184, 0.3);
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-}
-
-.deck-toggles {
-    background: var(--card);
-    border-radius: 20px;
-    padding: 20px;
-    border: 1px solid rgba(148, 163, 184, 0.3);
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-}
-
-.toggle-row {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 12px;
-}
-
-.toggle-row label {
-    margin: 0;
-    color: var(--text);
-    font-weight: 600;
-}
-
-.switch {
-    width: 52px;
-    height: 28px;
-    border-radius: 999px;
-    background: rgba(148, 163, 184, 0.4);
-    border: none;
-    position: relative;
-    cursor: pointer;
-    transition: background 0.2s ease;
-}
-
-.switch:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-}
-
-.switch::after {
-    content: '';
-    position: absolute;
-    top: 4px;
-    left: 4px;
-    width: 20px;
-    height: 20px;
-    border-radius: 50%;
     background: #fff;
-    transition: transform 0.2s ease;
+    border-radius: 1.25rem;
+    font-size: 1.5rem;
+    box-shadow: var(--shadow-card);
 }
 
-.switch.on {
-    background: var(--accent);
-}
-
-.switch.on::after {
-    transform: translateX(24px);
-}
-
-.deck-secondary-actions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 12px;
-    margin-bottom: 24px;
-}
-
-.publish-card {
-    background: var(--card);
-    border: 1px dashed rgba(59, 130, 246, 0.4);
-    border-radius: 20px;
-    padding: 20px;
-    margin-bottom: 24px;
-}
-
-.deck-history ul {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-}
-
-.deck-history li {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(120px, auto));
-    gap: 12px;
-    padding: 12px 0;
-    border-bottom: 1px solid rgba(148, 163, 184, 0.3);
-    align-items: center;
-}
-
-.deck-history time {
-    color: var(--muted);
-    font-size: 13px;
-}
-
-.editor-form {
+.app-nav {
     display: flex;
     flex-direction: column;
-    gap: 24px;
+    gap: 0.75rem;
 }
 
-.editor-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: 24px;
-}
-
-.editor-side h2 {
-    margin: 0 0 12px;
-}
-
-.editor-side textarea,
-.editor-side input {
-    background: var(--card);
-}
-
-.editor-audio {
-    background: var(--card);
-    border-radius: 20px;
-    padding: 20px;
-    border: 1px solid rgba(148, 163, 184, 0.3);
-}
-
-.checkbox-inline {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    margin-top: 12px;
-    color: var(--muted);
-}
-
-.deck-assignment {
-    background: var(--card);
-    border-radius: 20px;
-    border: 1px solid rgba(148, 163, 184, 0.3);
-    padding: 20px;
-}
-
-.deck-assignment-list {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    margin-top: 16px;
-}
-
-.deck-checkbox {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 16px;
-    padding: 14px 16px;
-    border: 1px solid var(--border);
-    border-radius: 16px;
-}
-
-.deck-checkbox-control {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-}
-
-.deck-checkbox-control input[type="checkbox"] {
-    width: auto;
-}
-
-.deck-checkbox-name {
-    font-weight: 600;
-}
-
-.deck-checkbox-meta {
-    color: var(--muted);
-    font-size: 13px;
-}
-
-.deck-checkbox-switch {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-}
-
-.flip-toggle {
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-    width: 44px;
-    height: 24px;
-}
-
-.flip-toggle input {
-    opacity: 0;
-    width: 0;
-    height: 0;
-    position: absolute;
-}
-
-.flip-toggle-track {
-    position: absolute;
-    inset: 0;
-    border-radius: 999px;
-    background: rgba(148, 163, 184, 0.5);
-    transition: background 0.2s ease;
-}
-
-.flip-toggle-thumb {
-    position: absolute;
-    top: 3px;
-    left: 4px;
-    width: 18px;
-    height: 18px;
-    border-radius: 50%;
-    background: #fff;
-    box-shadow: 0 2px 6px rgba(15, 23, 42, 0.2);
-    transition: transform 0.2s ease;
-}
-
-.flip-toggle input:checked ~ .flip-toggle-track {
-    background: var(--accent);
-}
-
-.flip-toggle input:checked ~ .flip-toggle-thumb {
-    transform: translateX(18px);
-}
-
-.editor-actions {
-    display: flex;
-    justify-content: flex-start;
-    gap: 12px;
-}
-
-.delete-card-form {
-    margin: 0 0 24px;
-}
-
-.settings-profile {
-    display: flex;
-    align-items: center;
-    gap: 16px;
-}
-
-.avatar {
-    width: 56px;
-    height: 56px;
-    border-radius: 50%;
-    background: var(--accent);
-    color: #fff;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    font-weight: 700;
-    font-size: 22px;
-}
-
-.settings-section h3 {
-    margin-top: 0;
-}
-
-.settings-item {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    border-bottom: 1px solid var(--border);
-    padding: 14px 0;
-    gap: 16px;
-}
-
-.settings-toggle {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    gap: 0.35rem;
-    min-width: 90px;
-}
-
-.settings-hint {
-    margin: 0;
-    font-size: 0.85rem;
-    color: var(--muted);
-    text-align: end;
-}
-
-.settings-item:last-child {
-    border-bottom: none;
-}
-
-.settings-item span {
-    color: var(--muted);
-    font-size: 14px;
-}
-
-.settings-item.link {
-    color: var(--text);
-}
-
-.settings-item.link a {
-    color: var(--accent);
-    font-weight: 600;
-}
-
-.tts-form {
-    display: grid;
-    gap: 16px;
-}
-
-.tts-form select:disabled {
-    opacity: 0.6;
-}
-
-.tts-preview {
-    display: flex;
-    align-items: center;
-    gap: 16px;
-    margin-top: 16px;
-}
-
-.tts-preview .settings-hint {
-    text-align: left;
-}
-
-.tts-preview-card {
-    flex: 1;
-    background: var(--card-muted);
-    border-radius: 16px;
-    padding: 16px;
-    border: 1px solid var(--border);
-}
-
-.social-row {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-}
-
-.social {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px 16px;
-    border-radius: 12px;
-    border: 1px solid var(--border);
-    background: var(--card);
-    font-weight: 600;
-}
-
-.social.instagram { color: #e11d48; }
-.social.youtube { color: #ef4444; }
-.social.facebook { color: #2563eb; }
-
-.app-version {
-    margin-top: 16px;
-    color: var(--muted);
-    font-size: 13px;
-}
-
-.bottom-nav {
-    position: fixed;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(255, 255, 255, 0.96);
-    border-top: 1px solid var(--border);
-    display: flex;
-    justify-content: space-around;
-    padding: 12px 16px;
-    backdrop-filter: blur(18px);
-}
-
-.bottom-nav-item {
+.app-nav__link {
+    padding: 0.7rem 1rem;
+    border-radius: 1.1rem;
     color: var(--muted);
     font-weight: 600;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.app-nav__link:hover,
+.app-nav__link:focus-visible {
+    background: rgba(99, 102, 241, 0.1);
+    color: var(--accent-dark);
     text-decoration: none;
 }
 
-.bottom-nav-item.active {
-    color: var(--accent-dark);
+.app-nav__link.is-active {
+    background: var(--accent);
+    color: #fff;
+    box-shadow: 0 12px 24px rgba(99, 102, 241, 0.22);
 }
 
-.deck-sheet {
-    position: fixed;
-    inset: 0;
-    background: rgba(15, 23, 42, 0.35);
+.sidebar-footer {
+    margin-top: auto;
     display: flex;
-    justify-content: center;
-    align-items: flex-end;
-    padding: 24px;
-    z-index: 20;
+    flex-direction: column;
+    gap: 1rem;
+    color: var(--muted);
+    font-size: 0.9rem;
 }
 
-.deck-sheet[hidden] {
-    display: none;
+.sidebar-actions {
+    display: flex;
+    gap: 0.75rem;
 }
 
-.deck-sheet-content {
+.app-main {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.main-header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 1rem 2rem;
+}
+
+.main-header h2 {
+    margin: 0;
+    font-size: 2rem;
+}
+
+.main-subtitle {
+    margin: 0.3rem 0 0;
+    color: var(--muted);
+}
+
+.deck-picker {
+    min-width: 220px;
+}
+
+.deck-picker__form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.panel {
     background: var(--card);
-    border-radius: 24px 24px 12px 12px;
-    padding: 24px;
-    width: min(420px, 100%);
-    box-shadow: var(--shadow);
+    border-radius: 1.8rem;
+    padding: 1.8rem;
+    box-shadow: var(--shadow-card);
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
 }
 
-.deck-sheet-actions {
+.panel--form {
+    background: linear-gradient(160deg, rgba(99, 102, 241, 0.08), rgba(14, 165, 233, 0.08));
+}
+
+.panel-header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 1rem 2rem;
+    align-items: flex-start;
+}
+
+.panel-subtitle {
+    margin: 0.3rem 0 0;
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+.hero {
     display: grid;
-    gap: 12px;
-    margin-top: 16px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    align-items: center;
+    gap: 2rem;
+    background: linear-gradient(120deg, rgba(99, 102, 241, 0.12), rgba(14, 165, 233, 0.1));
 }
 
-.sheet-action {
-    width: 100%;
-    border: none;
-    border-radius: 14px;
-    padding: 12px;
-    background: var(--card-muted);
-    cursor: pointer;
+.hero__content h3 {
+    margin: 0;
+    font-size: 1.75rem;
+}
+
+.hero__content p {
+    margin: 0.75rem 0 1.25rem;
+    color: var(--muted);
+}
+
+.hero-metrics {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+    margin: 0;
+}
+
+.hero-metrics dt {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-bottom: 0.35rem;
+}
+
+.hero-metrics dd {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 700;
+}
+
+.hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.inline-form {
+    display: inline-flex;
+}
+
+.inline-form .btn {
+    border-radius: 1.1rem;
+}
+
+.hero__visual {
+    text-align: center;
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+.hero-bubble {
+    width: 140px;
+    height: 140px;
+    margin: 0 auto 1rem;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    font-size: 2.5rem;
+    background: #fff;
+    box-shadow: var(--shadow-card);
+}
+
+.sample-card__body {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1.5rem;
+}
+
+.sample-card__label {
+    display: inline-block;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted);
+    margin-bottom: 0.35rem;
+}
+
+.sample-card__word strong {
+    font-size: 2.4rem;
+    line-height: 1.2;
+}
+
+.sample-card__translit {
+    color: var(--muted);
+    font-size: 1rem;
+}
+
+.sample-card__meaning p,
+.sample-card__alt {
+    margin: 0.3rem 0;
+    font-size: 1.05rem;
+}
+
+.stacked-form {
+    display: grid;
+    gap: 1.1rem;
+}
+
+.history-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.9rem;
+}
+
+.history-list li {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.history-list li:last-child {
+    border-bottom: none;
+}
+
+.history-translit {
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.history-meta {
+    color: var(--muted);
+    font-size: 0.85rem;
+}
+
+.deck-list {
+    display: grid;
+    gap: 1.2rem;
+}
+
+.deck-card {
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    border-radius: 1.4rem;
+    padding: 1.35rem;
+    background: #fff;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.deck-card.is-selected {
+    border-color: rgba(99, 102, 241, 0.55);
+    box-shadow: 0 12px 28px rgba(99, 102, 241, 0.18);
+}
+
+.deck-card__description {
+    margin: 0.35rem 0 0;
+    color: var(--muted);
+}
+
+.deck-card__stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 0.75rem;
+    margin: 0;
+}
+
+.deck-card__stats dt {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+}
+
+.deck-card__stats dd {
+    margin: 0.2rem 0 0;
+    font-size: 1.15rem;
     font-weight: 600;
 }
 
-.sheet-action.danger {
-    color: #b91c1c;
-    background: rgba(248, 113, 113, 0.18);
+.deck-card__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
 }
 
-.dialog {
+.deck-card__meta {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.85rem;
+}
+
+.toggle-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.2rem;
+}
+
+.toggle-card {
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    border-radius: 1.4rem;
+    padding: 1.25rem;
+    background: var(--card);
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+}
+
+.toggle-card h4 {
+    margin: 0;
+}
+
+.toggle-card p {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.toggle-button {
+    border-radius: 999px;
+    border: none;
+    padding: 0.55rem 1.2rem;
+    background: var(--card-muted);
+    color: var(--text);
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.toggle-button.is-on {
+    background: var(--accent);
+    color: #fff;
+    box-shadow: 0 12px 24px rgba(99, 102, 241, 0.25);
+}
+
+.empty-state {
+    margin: 0;
+    color: var(--muted);
+}
+
+.toast-region {
     position: fixed;
-    inset: 0;
-    background: rgba(15, 23, 42, 0.35);
+    inset-inline: 0;
+    top: 1.5rem;
     display: flex;
     justify-content: center;
+    pointer-events: none;
+    z-index: 999;
+}
+
+.toast {
+    background: #111827;
+    color: #fff;
+    padding: 0.85rem 1.35rem;
+    border-radius: 999px;
+    box-shadow: 0 14px 30px rgba(15, 23, 42, 0.25);
+    display: inline-flex;
+    gap: 0.6rem;
     align-items: center;
-    padding: 24px;
-    z-index: 30;
 }
 
-.dialog[hidden] {
-    display: none;
+/* Authentication */
+body.auth-body {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 3rem 1.5rem;
+    background: var(--bg-accent);
 }
 
-.dialog-content {
+.auth-card {
     background: var(--card);
-    padding: 24px;
-    border-radius: 20px;
-    box-shadow: var(--shadow);
+    padding: 2.5rem;
+    border-radius: 1.8rem;
+    box-shadow: var(--shadow-soft);
     width: min(420px, 100%);
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 1.5rem;
 }
 
-.dialog-list {
+.auth-title {
+    margin: 0;
+    text-align: center;
+}
+
+.auth-form {
+    display: grid;
+    gap: 1rem;
+}
+
+.auth-btn {
+    justify-content: center;
+}
+
+.auth-switch {
+    margin: 0;
+    text-align: center;
+    color: var(--muted);
+}
+
+/* Study screen */
+body.study-body {
+    margin: 0;
+    min-height: 100vh;
+    background: radial-gradient(circle at top, rgba(99, 102, 241, 0.12), transparent 55%), var(--bg);
+    color: var(--text);
+    display: flex;
+    flex-direction: column;
+}
+
+.study-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1.5rem;
+    gap: 1rem;
+    background: rgba(255, 255, 255, 0.8);
+    backdrop-filter: blur(14px);
+}
+
+.study-header__titles h1 {
+    margin: 0;
+    font-size: 1.75rem;
+}
+
+.study-header__titles p {
+    margin: 0.35rem 0 0;
+    color: var(--muted);
+}
+
+.study-header__meta {
+    text-align: center;
+    background: var(--card);
+    padding: 0.6rem 1rem;
+    border-radius: 1rem;
+    box-shadow: var(--shadow-card);
+}
+
+.study-main {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem 1.5rem 3.5rem;
+}
+
+.study-card {
+    width: min(560px, 100%);
+    background: var(--card);
+    border-radius: 2rem;
+    box-shadow: var(--shadow-soft);
+    padding: 2.5rem;
+    display: grid;
+    gap: 1.25rem;
+}
+
+.study-card__media {
+    display: flex;
+    justify-content: center;
+}
+
+.study-card__media img {
+    max-width: 220px;
+    border-radius: 1.25rem;
+    box-shadow: var(--shadow-card);
+}
+
+.study-card__content {
+    text-align: center;
+    display: grid;
+    gap: 0.65rem;
+}
+
+.study-card__label {
+    margin: 0;
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+}
+
+.study-card__content h2 {
+    margin: 0;
+    font-size: 2.4rem;
+}
+
+.study-card__translit {
+    color: var(--muted);
+    font-size: 1rem;
+}
+
+.study-card__translations,
+.study-card__notes {
+    margin: 0;
     list-style: none;
     padding: 0;
-    margin: 12px 0;
-    display: grid;
-    gap: 8px;
+    color: var(--muted);
 }
 
-.dialog-grid {
-    display: grid;
-    gap: 12px;
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+.study-card__translations li {
+    margin-bottom: 0.35rem;
 }
 
-.icon-option {
-    border: 1px solid var(--border);
-    border-radius: 16px;
-    padding: 12px;
-    background: var(--card);
-    cursor: pointer;
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.icon-option.selected {
-    border-color: var(--accent);
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.25);
-}
-
-.icon-option:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
-}
-
-.dialog-actions {
+.study-card__footer {
     display: flex;
-    justify-content: flex-end;
-    gap: 12px;
+    justify-content: center;
+    gap: 0.75rem;
 }
 
-@media (max-width: 768px) {
-    .app-shell {
-        padding: 16px 16px 90px;
+.study-empty {
+    text-align: center;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.study-actions {
+    position: sticky;
+    bottom: 0;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.85rem;
+    padding: 1.25rem;
+    background: rgba(255, 255, 255, 0.94);
+    backdrop-filter: blur(14px);
+}
+
+.srs-btn {
+    border-radius: 1.2rem;
+    border: none;
+    padding: 0.85rem 1.1rem;
+    font-weight: 700;
+    font-size: 1rem;
+    cursor: pointer;
+    background: var(--card-muted);
+    color: var(--text);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.srs-btn:hover,
+.srs-btn:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 18px rgba(15, 23, 42, 0.15);
+}
+
+.srs-btn[data-result="again"] {
+    background: rgba(239, 68, 68, 0.15);
+    color: var(--danger);
+}
+
+.srs-btn[data-result="easy"] {
+    background: rgba(34, 197, 94, 0.15);
+    color: var(--success);
+}
+
+@media (max-width: 980px) {
+    .app-container {
+        grid-template-columns: 1fr;
+        padding: 2.25rem;
     }
 
-    .search-form {
+    .app-sidebar {
+        flex-direction: row;
+        flex-wrap: wrap;
+        align-items: center;
+    }
+
+    .app-nav {
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+
+    .sidebar-footer {
         width: 100%;
-        padding: 10px;
-    }
-
-    .search-form input[type="text"] {
-        min-width: 0;
-        flex: 1;
-    }
-
-    .hero-card {
-        grid-template-columns: 1fr;
-    }
-
-    .deck-grid {
-        grid-template-columns: 1fr;
-    }
-
-    .bottom-nav {
-        padding: 10px 12px;
     }
 }
 
-@media (max-width: 480px) {
-    .flashcard {
-        flex-basis: 90vw;
+@media (max-width: 720px) {
+    body.app-body {
+        padding: 2rem 1rem;
     }
 
-    .memory-board {
-        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    .app-container {
+        padding: 2rem 1.25rem;
+        border-radius: 2rem;
     }
 
-    .hero-stats {
-        justify-content: space-between;
+    .study-card {
+        padding: 1.8rem;
+    }
+
+    .study-actions {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (max-width: 520px) {
+    .hero-actions {
+        flex-direction: column;
+    }
+
+    .sidebar-actions {
+        width: 100%;
+        flex-direction: column;
     }
 }


### PR DESCRIPTION
## Summary
- replace the monolithic dashboard with modular partials for the home, library, and settings screens while keeping actions intact
- add a safe dashboard_redirect helper so deck actions can return to the requested screen
- refresh the visual language with a centered layout, simplified controls, and updated study/auth styling

## Testing
- php -l index.php
- php -l partials/home.php
- php -l partials/library.php
- php -l partials/settings.php
- php -l lib/dashboard_actions.php

------
https://chatgpt.com/codex/tasks/task_e_68d6cc182094832b9dcf1ab58b948626