### PR TITLE
Fix translation fallback title

### DIFF
--- a/index.php
+++ b/index.php
@@ -102,7 +102,7 @@ $navLinks = [
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title><?= h(t('app.name_fallback', 'Hebrew Study Hub')) ?></title>
+    <title><?= h(t('app.name_fallback')) ?></title>
     <link rel="stylesheet" href="styles.css">
 </head>
 <body class="app-body" data-screen="<?= h($screen) ?>">

--- a/lang/en.php
+++ b/lang/en.php
@@ -2,6 +2,7 @@
 return [
     'app' => [
         'name' => 'Hebrew Study Hub',
+        'name_fallback' => 'Hebrew Study Hub',
         'tagline' => 'A Noji-inspired spaced repetition workspace for mastering Hebrew vocabulary.',
         'subtitle' => 'A focused dashboard that keeps everything you need to review at your own pace.',
         'language_label' => 'Language',

--- a/lang/he.php
+++ b/lang/he.php
@@ -2,6 +2,7 @@
 return [
     'app' => [
         'name' => 'Hebrew Study Hub',
+        'name_fallback' => 'Hebrew Study Hub',
         'tagline' => 'חוויית חזרתיות מבוזרת בהשראת Noji ללמידת עברית.',
         'subtitle' => 'לוח מחוונים ממוקד שמרכז את כל מה שצריך כדי לחזור בקצב האישי שלך.',
         'language_label' => 'שפה',

--- a/lang/ru.php
+++ b/lang/ru.php
@@ -2,6 +2,7 @@
 return [
     'app' => [
         'name' => 'Hebrew Study Hub',
+        'name_fallback' => 'Hebrew Study Hub',
         'tagline' => 'Пространство интервальных повторений в стиле Noji для изучения иврита.',
         'subtitle' => 'Сфокусированная панель, которая держит всё необходимое для повторения в вашем темпе.',
         'language_label' => 'Язык',


### PR DESCRIPTION
## Summary
- remove the invalid fallback argument when rendering the dashboard title
- add a dedicated `app.name_fallback` key across all locale bundles so the translation lookup succeeds

## Testing
- php -l index.php lang/en.php lang/he.php lang/ru.php

------
https://chatgpt.com/codex/tasks/task_e_68d706e551f4832bbd927dbe36e635dc