### PR TITLE
Handle string replacements in translation helper

### DIFF
--- a/lib/i18n.php
+++ b/lib/i18n.php
@@ -105,7 +105,7 @@ function translation_lookup(string $key, array $dictionary)
     return $value;
 }
 
-function t(string $key, array $replacements = []): string
+function t(string $key, array|string $replacements = []): string
 {
     $bundle = $GLOBALS['__i18n'] ?? null;
     if ($bundle === null) {
@@ -119,6 +119,14 @@ function t(string $key, array $replacements = []): string
     }
     if (!is_string($value)) {
         $value = $key;
+    }
+
+    if (!is_array($replacements)) {
+        if ($replacements === '') {
+            $replacements = [];
+        } else {
+            $replacements = ['value' => $replacements];
+        }
     }
 
     if ($replacements) {


### PR DESCRIPTION
## Summary
- allow the translation helper to accept string replacement arguments by normalizing them internally
- prevent runtime type errors when translations are rendered with scalar replacements

## Testing
- php -l lib/i18n.php

------
https://chatgpt.com/codex/tasks/task_e_68d712460fc8832b923e397be3748225